### PR TITLE
Add organizationId to practice details responses

### DIFF
--- a/src/modules/practice/services/practice-details.service.ts
+++ b/src/modules/practice/services/practice-details.service.ts
@@ -83,6 +83,7 @@ const getPracticeDetails = async (
         'created_at',
         'updated_at',
       ]),
+      organizationId,
       address: addressData,
       services: services.map((s) => ({ id: s.id, name: s.name, key: s.key })),
       is_public: fetchedDetails?.is_public ?? false,
@@ -210,6 +211,7 @@ const upsertPracticeDetails = async (
         'created_at',
         'updated_at',
       ]),
+      organizationId,
       address: practiceDetailsResult.addressResult,
       services: practiceDetailsResult.syncedServices.map((s) => ({ id: s.id, name: s.name, key: s.key })),
     };
@@ -329,6 +331,7 @@ const getPracticeDetailsBySlug = async (
         'created_at',
         'updated_at',
       ]),
+      organizationId: organization.id,
       address: addressData,
       services: services.map((s) => ({ id: s.id, name: s.name, key: s.key })),
       name: organization.name,

--- a/src/modules/practice/services/practice-details.service.ts
+++ b/src/modules/practice/services/practice-details.service.ts
@@ -38,7 +38,7 @@ const getPracticeDetails = async (
   try {
     // 1. Verify organization exists and user has access via Better Auth
     const organizationResult = await getFullOrganization(
-      organizationId,
+      organization_id: organizationId,
       user,
       requestHeaders,
     );
@@ -83,7 +83,7 @@ const getPracticeDetails = async (
         'created_at',
         'updated_at',
       ]),
-      organizationId,
+      organization_id: organizationId,
       address: addressData,
       services: services.map((s) => ({ id: s.id, name: s.name, key: s.key })),
       is_public: fetchedDetails?.is_public ?? false,
@@ -108,7 +108,7 @@ const upsertPracticeDetails = async (
   try {
     // 1. Verify organization exists and user has access via Better Auth
     const orgResult = await getFullOrganization(
-      organizationId,
+      organization_id: organizationId,
       user,
       requestHeaders,
     );
@@ -211,7 +211,7 @@ const upsertPracticeDetails = async (
         'created_at',
         'updated_at',
       ]),
-      organizationId,
+      organization_id: organizationId,
       address: practiceDetailsResult.addressResult,
       services: practiceDetailsResult.syncedServices.map((s) => ({ id: s.id, name: s.name, key: s.key })),
     };
@@ -331,7 +331,7 @@ const getPracticeDetailsBySlug = async (
         'created_at',
         'updated_at',
       ]),
-      organizationId: organization.id,
+      organization_id: organization.id,
       address: addressData,
       services: services.map((s) => ({ id: s.id, name: s.name, key: s.key })),
       name: organization.name,

--- a/src/modules/practice/types/practice-details.types.ts
+++ b/src/modules/practice/types/practice-details.types.ts
@@ -5,6 +5,7 @@ export type PracticeDetailsResponse = Omit<
   PracticeDetails,
   'id' | 'organization_id' | 'user_id' | 'address_id' | 'created_at' | 'updated_at' | 'services'
 > & {
+  organizationId: string;
   address?: AddressData | null;
   services: Array<{ id: string; name: string; key: string }>;
   name?: string;

--- a/src/modules/practice/types/practice-details.types.ts
+++ b/src/modules/practice/types/practice-details.types.ts
@@ -5,7 +5,7 @@ export type PracticeDetailsResponse = Omit<
   PracticeDetails,
   'id' | 'organization_id' | 'user_id' | 'address_id' | 'created_at' | 'updated_at' | 'services'
 > & {
-  organizationId: string;
+  organization_id: string;
   address?: AddressData | null;
   services: Array<{ id: string; name: string; key: string }>;
   name?: string;

--- a/src/modules/practice/validations/practice.validation.ts
+++ b/src/modules/practice/validations/practice.validation.ts
@@ -395,6 +395,10 @@ const practiceDetailsResponseSchema = z
     intro_message: z.string().nullable().openapi({ example: 'Welcome' }),
     overview: z.string().nullable().openapi({ example: 'Overview text' }),
     is_public: z.boolean().openapi({ example: true }),
+    organizationId: z.string().uuid().openapi({
+      description: 'Organization UUID for the practice',
+      example: '9f7a2c1f-8e5c-4b8a-9d7f-1234567890ab',
+    }),
     services: z
       .array(z.object({ id: z.string(), name: z.string(), key: z.string() }))
       .nullable()

--- a/src/modules/practice/validations/practice.validation.ts
+++ b/src/modules/practice/validations/practice.validation.ts
@@ -395,7 +395,7 @@ const practiceDetailsResponseSchema = z
     intro_message: z.string().nullable().openapi({ example: 'Welcome' }),
     overview: z.string().nullable().openapi({ example: 'Overview text' }),
     is_public: z.boolean().openapi({ example: true }),
-    organizationId: z.string().uuid().openapi({
+    organization_id: z.string().uuid().openapi({
       description: 'Organization UUID for the practice',
       example: '9f7a2c1f-8e5c-4b8a-9d7f-1234567890ab',
     }),


### PR DESCRIPTION
### Motivation
- The public embed flow needs the canonical organization UUID when fetching a practice profile so it can avoid an extra call to the intake endpoint and map slugs to orgs directly.
- Ensure both authenticated and public practice details responses include the same organization identifier for consistency and routing simplification.

### Description
- Return `organizationId` in practice details responses from the service functions `getPracticeDetails`, `upsertPracticeDetails`, and `getPracticeDetailsBySlug` by adding the field into the assembled `responseData` objects in `src/modules/practice/services/practice-details.service.ts`.
- Add `organizationId: string` to the `PracticeDetailsResponse` TypeScript type in `src/modules/practice/types/practice-details.types.ts`.
- Update the OpenAPI/validation schema `practiceDetailsResponseSchema` to include `organizationId` (UUID) in `src/modules/practice/validations/practice.validation.ts` so the field is documented for the API.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697998176bc48321ad810e997e2d7e12)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Practice Details responses now include the associated organization identifier, making organization context available across all practice detail endpoints.

* **Documentation**
  * API response schema and documentation updated to describe the new organization identifier field (type: UUID) and provide an example.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->