### PR TITLE
Accept new onboarding categories for `primary_use_case` and `product_usage`

### DIFF
--- a/src/modules/preferences/types/preferences.types.ts
+++ b/src/modules/preferences/types/preferences.types.ts
@@ -3,6 +3,11 @@ import { preferenceValidations } from '@/modules/preferences/validations/prefere
 
 // Product usage options enum
 export const PRODUCT_USAGE_OPTIONS = [
+  'messaging',
+  'legal_payments',
+  'matter_management',
+  'intake_forms',
+  'other',
   'personal_legal_issue',
   'business_legal_needs',
   'legal_research',

--- a/src/modules/preferences/validations/preferences.validation.ts
+++ b/src/modules/preferences/validations/preferences.validation.ts
@@ -92,7 +92,7 @@ const accountPreferencesSchema = z.object({
 
 const onboardingPreferencesSchema = z.object({
   birthday: z.string().optional(), // ISO date string
-  primary_use_case: z.string().optional(),
+  primary_use_case: z.enum(PRODUCT_USAGE_OPTIONS).optional(),
   use_case_additional_info: z.string().optional(),
   completed: z.boolean().optional(),
   product_usage: z.array(z.enum(PRODUCT_USAGE_OPTIONS)).max(5).optional(),
@@ -191,4 +191,3 @@ export const preferenceValidations = {
   notFoundResponseSchema,
   internalServerErrorResponseSchema,
 };
-


### PR DESCRIPTION
### Motivation
- The frontend now sends new onboarding categories (`messaging`, `legal_payments`, `matter_management`, `intake_forms`, `other`) and the backend must accept them to avoid 400 errors when saving onboarding preferences.

### Description
- Added the new UI categories to the `PRODUCT_USAGE_OPTIONS` enum in `src/modules/preferences/types/preferences.types.ts` while retaining legacy values for backward compatibility.
- Updated the onboarding validation to validate `primary_use_case` against the `PRODUCT_USAGE_OPTIONS` enum by changing it to `z.enum(PRODUCT_USAGE_OPTIONS)` in `src/modules/preferences/validations/preferences.validation.ts`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697add2c2ac08321a5b396abfa8ea0a6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added five new product usage category options: messaging, legal payments, matter management, intake forms, and other.

* **Improvements**
  * Enhanced validation for product usage preference selection to ensure consistency with supported options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->