### PR TITLE
feat: rename address fields and add intake address support

### DIFF
--- a/migrations/20250202_rename_address_fields.sql
+++ b/migrations/20250202_rename_address_fields.sql
@@ -1,0 +1,11 @@
+-- Migration: Rename address fields to be more semantic
+-- Date: 2025-02-02
+-- Purpose: Rename line1 → address, line2 → apartment for clarity
+
+-- Rename columns to be more semantic
+ALTER TABLE addresses RENAME COLUMN line1 TO address;
+ALTER TABLE addresses RENAME COLUMN line2 TO apartment;
+
+-- Add comment for clarity
+COMMENT ON COLUMN addresses.address IS 'Street address line 1';
+COMMENT ON COLUMN addresses.apartment IS 'Apartment, suite, or unit number';

--- a/src/modules/practice-client-intakes/types/practice-client-intakes.types.ts
+++ b/src/modules/practice-client-intakes/types/practice-client-intakes.types.ts
@@ -27,6 +27,14 @@ export type ClientIntake = {
   customer_email: string;
   customer_name: string;
   customer_phone?: string | null;
+  customer_address?: {
+    address?: string | null;
+    apartment?: string | null;
+    city?: string | null;
+    state?: string | null;
+    postal_code?: string | null;
+    country?: string | null;
+  } | null;
   on_behalf_of?: string | null;
   opposing_party?: string | null;
   description?: string | null;

--- a/src/modules/practice-client-intakes/validations/practice-client-intakes.validation.ts
+++ b/src/modules/practice-client-intakes/validations/practice-client-intakes.validation.ts
@@ -7,6 +7,14 @@ const createPracticeClientIntakeSchema = z.object({
   email: z.email().max(255),
   name: z.string().min(1).max(200),
   phone: z.string().max(50).optional(),
+  address: z.object({
+    address: z.string().optional(),
+    apartment: z.string().optional(),
+    city: z.string().optional(),
+    state: z.string().optional(),
+    postal_code: z.string().optional(),
+    country: z.string().optional(),
+  }).optional(),
   on_behalf_of: z.string().max(200).optional(),
   opposing_party: z.string().max(200).optional().openapi({
     description: 'Name of the opposing party in the legal matter',

--- a/src/modules/practice/database/schema/addresses.schema.ts
+++ b/src/modules/practice/database/schema/addresses.schema.ts
@@ -13,8 +13,8 @@ export const addresses = pgTable(
     }),
     user_id: uuid('user_id').references(() => users.id, { onDelete: 'cascade' }),
     type: text('type').notNull().default('practice_location'), // e.g., 'practice_location', 'billing', 'home'
-    line1: text('line1'),
-    line2: text('line2'),
+    address: text('address'),        // was line1
+    apartment: text('apartment'),    // was line2
     city: text('city'),
     state: text('state'),
     postal_code: text('postal_code'),

--- a/src/modules/practice/types/addresses.types.ts
+++ b/src/modules/practice/types/addresses.types.ts
@@ -1,6 +1,6 @@
 export type AddressData = {
-  line1?: string | null;
-  line2?: string | null;
+  address?: string | null;      // was line1
+  apartment?: string | null;    // was line2
   city?: string | null;
   state?: string | null;
   postal_code?: string | null;


### PR DESCRIPTION
- Rename database columns: line1 → address, line2 → apartment
- Update AddressData type to use new field names
- Add address field to intake validation schema
- Add customer_address to ClientIntake type
- Add migration script for database changes

This provides more semantic field names and enables address collection in intake forms while maintaining snake_case API consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Address field structure updated with revised naming conventions for consistency

* **New Features**
  * Customer address capture now available in client intake forms, supporting street address, apartment/unit, city, state, postal code, and country information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->