### PR TITLE
Fix redirect url for invitations

### DIFF
--- a/src/shared/auth/better-auth.ts
+++ b/src/shared/auth/better-auth.ts
@@ -56,7 +56,7 @@ const betterAuthConfig = (db: NodePgDatabase<typeof schema>) => betterAuth({
 
         // Queue the invitation email
         await addEmailJob(
-          'team-invitation',
+          'practice-invitation',
           data.email,
           `You've been invited to join ${practiceName} on Blawby`,
           {

--- a/src/shared/auth/better-auth.ts
+++ b/src/shared/auth/better-auth.ts
@@ -52,19 +52,19 @@ const betterAuthConfig = (db: NodePgDatabase<typeof schema>) => betterAuth({
         },
       },
       sendInvitationEmail: async (data) => {
-        const teamName = data.organization.name || 'the team';
+        const practiceName = data.organization.name || 'the team';
 
         // Queue the invitation email
         await addEmailJob(
           'team-invitation',
           data.email,
-          `You've been invited to join ${teamName} on Blawby`,
+          `You've been invited to join ${practiceName} on Blawby`,
           {
             recipientEmail: data.email,
             recipientName: '', // Optional
             inviterName: data.inviter.user.name || data.inviter.user.email,
-            teamName,
-            inviteLink: `${process.env.BASE_URL}/api/auth/accept-invitation/${data.id}`,
+            practiceName,
+            inviteLink: `${process.env.FRONTEND_URL}/auth/accept-invitation?invitationId=${data.id}`,
           },
         );
 

--- a/src/shared/services/email/email.types.ts
+++ b/src/shared/services/email/email.types.ts
@@ -17,7 +17,7 @@ export const EMAIL_TEMPLATES = {
   TEAM_PAYMENT_RECEIPT: 'team-payment-receipt',
   TEAM_CUSTOM_RECEIPT: 'team-custom-receipt',
   TEAM_REFUND_REQUEST: 'team-refund-request',
-  TEAM_INVITATION: 'team-invitation',
+  PRACTICE_INVITATION: 'practice-invitation',
   // Onboarding emails
   WELCOME: 'welcome',
   STRIPE_CONNECT_WELCOME: 'stripe-connect-welcome',

--- a/src/shared/services/email/email.types.ts
+++ b/src/shared/services/email/email.types.ts
@@ -144,10 +144,10 @@ export interface RefundData extends BaseEmailData {
   supportUrl?: string;
 }
 
-// Team invitation data
-export interface TeamInvitationData extends BaseEmailData {
+// Practice invitation data
+export interface PracticeInvitationData extends BaseEmailData {
   inviterName: string;
-  teamName: string;
+  practiceName: string;
   inviteLink: string;
 }
 

--- a/src/shared/services/email/templates/index.ts
+++ b/src/shared/services/email/templates/index.ts
@@ -16,7 +16,7 @@ import {
   type PayoutSentData,
   type ScheduledEventData,
   type MagicLinkData,
-  type TeamInvitationData,
+  type PracticeInvitationData,
 } from '@/shared/services/email/email.types';
 
 // Auth templates
@@ -37,7 +37,7 @@ import { scheduledEventTemplate } from '@/shared/services/email/templates/schedu
 
 // Team templates
 import { teamPaymentReceipt } from '@/shared/services/email/templates/team/payment-receipt';
-import { teamInvitation } from '@/shared/services/email/templates/team/team-invitation';
+import { practiceInvitation } from '@/shared/services/email/templates/team/practice-invitation';
 
 
 /**
@@ -53,7 +53,7 @@ export interface TemplateDataMap {
   [EMAIL_TEMPLATES.TEAM_PAYMENT_RECEIPT]: TeamPaymentReceiptData;
   [EMAIL_TEMPLATES.TEAM_CUSTOM_RECEIPT]: TeamPaymentReceiptData;
   [EMAIL_TEMPLATES.TEAM_REFUND_REQUEST]: TeamPaymentReceiptData;
-  [EMAIL_TEMPLATES.TEAM_INVITATION]: TeamInvitationData;
+  [EMAIL_TEMPLATES.PRACTICE_INVITATION]: PracticeInvitationData;
   [EMAIL_TEMPLATES.WELCOME]: WelcomeEmailData;
   [EMAIL_TEMPLATES.STRIPE_CONNECT_WELCOME]: StripeConnectWelcomeData;
   [EMAIL_TEMPLATES.STRIPE_CONNECT_STATUS]: StripeConnectStatusData;
@@ -79,7 +79,9 @@ const templateRegistry = {
   [EMAIL_TEMPLATES.TEAM_PAYMENT_RECEIPT]: teamPaymentReceipt,
   [EMAIL_TEMPLATES.TEAM_CUSTOM_RECEIPT]: teamPaymentReceipt, // Reusing team receipt for custom cases
   [EMAIL_TEMPLATES.TEAM_REFUND_REQUEST]: teamPaymentReceipt, // Intentional reuse: notification uses team receipt layout
-  [EMAIL_TEMPLATES.TEAM_INVITATION]: teamInvitation,
+  [EMAIL_TEMPLATES.PRACTICE_INVITATION]: practiceInvitation,
+
+  // Onboarding templates
 
   // Onboarding templates
   [EMAIL_TEMPLATES.WELCOME]: welcomeEmail,
@@ -112,7 +114,7 @@ export {
   customerPaymentRequest,
   teamPaymentReceipt,
   welcomeEmail,
-  teamInvitation,
+  practiceInvitation,
   stripeConnectWelcome,
   stripeConnectStatus,
   payoutSent,

--- a/src/shared/services/email/templates/team/practice-invitation.ts
+++ b/src/shared/services/email/templates/team/practice-invitation.ts
@@ -1,7 +1,3 @@
-/**
- * Team Invitation Email Template
- */
-
 import { type PracticeInvitationData } from '@/shared/services/email/email.types';
 import {
   baseLayout,
@@ -17,7 +13,7 @@ import {
  * Renders an invitation email for a user to join an organization.
  * Uses the PracticeInvitationData structure: { recipientEmail, recipientName, inviterName, practiceName, inviteLink }
  */
-export const teamInvitation = (data: PracticeInvitationData): string => {
+export const practiceInvitation = (data: PracticeInvitationData): string => {
   const recipientName = escapeHtml(data.recipientName || 'there');
   const inviterName = escapeHtml(data.inviterName);
   const practiceName = escapeHtml(data.practiceName);

--- a/src/shared/services/email/templates/team/team-invitation.ts
+++ b/src/shared/services/email/templates/team/team-invitation.ts
@@ -2,7 +2,7 @@
  * Team Invitation Email Template
  */
 
-import { type TeamInvitationData } from '@/shared/services/email/email.types';
+import { type PracticeInvitationData } from '@/shared/services/email/email.types';
 import {
   baseLayout,
   cardSection,
@@ -15,12 +15,12 @@ import {
 
 /**
  * Renders an invitation email for a user to join an organization.
- * Uses the TeamInvitationData structure: { recipientEmail, recipientName, inviterName, teamName, inviteLink }
+ * Uses the PracticeInvitationData structure: { recipientEmail, recipientName, inviterName, practiceName, inviteLink }
  */
-export const teamInvitation = (data: TeamInvitationData): string => {
+export const teamInvitation = (data: PracticeInvitationData): string => {
   const recipientName = escapeHtml(data.recipientName || 'there');
   const inviterName = escapeHtml(data.inviterName);
-  const teamName = escapeHtml(data.teamName);
+  const practiceName = escapeHtml(data.practiceName);
   const sanitizedInviteLink = sanitizeUrl(data.inviteLink);
   const escapedInviteLink = escapeHtml(sanitizedInviteLink);
 
@@ -29,7 +29,7 @@ export const teamInvitation = (data: TeamInvitationData): string => {
     ${cardSection(`
       <mj-column>
         <mj-text color="${COLORS.text}" font-size="20px" font-weight="700" padding-bottom="10px">
-          You've been invited to join ${teamName} on Blawby
+          You've been invited to join ${practiceName} on Blawby
         </mj-text>
         
         <mj-text color="${COLORS.text}" font-size="16px" line-height="24px">
@@ -37,7 +37,7 @@ export const teamInvitation = (data: TeamInvitationData): string => {
         </mj-text>
         
         <mj-text color="${COLORS.text}" font-size="16px" line-height="24px">
-          <strong>${inviterName}</strong> has invited you to join their team, <strong>${teamName}</strong>, on Blawby.
+          <strong>${inviterName}</strong> has invited you to join their practice, <strong>${practiceName}</strong>, on Blawby.
         </mj-text>
         
         <mj-text color="${COLORS.text}" font-size="16px" line-height="24px" padding-bottom="20px">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Invitation email subject and copy updated to use "practice" instead of "team".
  * Invitation messages and templates refreshed to reflect the new terminology throughout.
  * Invitation acceptance link format updated for improved consistency and routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->