### PR TITLE
feat: Add accent_color to practice details

### DIFF
--- a/src/modules/practice/database/schema/practice.schema.ts
+++ b/src/modules/practice/database/schema/practice.schema.ts
@@ -28,6 +28,7 @@ export const practiceDetails = pgTable('practice_details', {
   calendly_url: text('calendly_url'),
   intro_message: text('intro_message'),
   overview: text('overview'),
+  accent_color: text('accent_color'),
   is_public: boolean('is_public').default(false).notNull(),
   billing_increment_minutes: integer('billing_increment_minutes').default(1).notNull(),
   created_at: timestamp('created_at').defaultNow().notNull(),

--- a/src/modules/practice/services/practice-details.service.ts
+++ b/src/modules/practice/services/practice-details.service.ts
@@ -165,6 +165,7 @@ const upsertPracticeDetails = async (
           website: data.website ?? undefined,
           intro_message: data.intro_message ?? undefined,
           overview: data.overview ?? undefined,
+          accent_color: data.accent_color ?? undefined,
           is_public: data.is_public ?? undefined,
           billing_increment_minutes: data.billing_increment_minutes ?? undefined,
         })
@@ -180,6 +181,7 @@ const upsertPracticeDetails = async (
             website: data.website ?? undefined,
             intro_message: data.intro_message ?? undefined,
             overview: data.overview ?? undefined,
+            accent_color: data.accent_color ?? undefined,
             is_public: data.is_public ?? undefined,
             billing_increment_minutes: data.billing_increment_minutes ?? undefined,
             updated_at: new Date(),

--- a/src/modules/practice/types/practice-details.types.ts
+++ b/src/modules/practice/types/practice-details.types.ts
@@ -24,6 +24,7 @@ export type UpsertPracticeDetailsRequest = {
   website?: string | null;
   intro_message?: string | null;
   overview?: string | null;
+  accent_color?: string | null;
   is_public?: boolean;
   billing_increment_minutes?: number;
   services?: Array<{ id?: string; name: string; key: string }>;

--- a/src/modules/practice/validations/practice.validation.ts
+++ b/src/modules/practice/validations/practice.validation.ts
@@ -40,6 +40,7 @@ const practiceDetailsValidationSchema = z.object({
   website: urlValidator.optional().or(z.literal('')).openapi({ example: 'https://example.com' }),
   intro_message: z.string().optional().openapi({ example: 'Welcome to our practice' }),
   overview: z.string().optional().openapi({ example: 'We specialize in family law' }),
+  accent_color: z.string().optional().openapi({ example: '#3B82F6' }),
   is_public: z.boolean().optional().openapi({ example: true }),
   billing_increment_minutes: billingIncrementMinutesSchema.optional(),
   services: z
@@ -153,6 +154,10 @@ const practiceResponseSchema = z
     overview: z.string().nullable().openapi({
       description: 'Detailed practice overview or biography',
       example: 'We specialize in family and corporate law with over 20 years of experience.',
+    }),
+    accent_color: z.string().nullable().openapi({
+      description: 'Practice accent color for theming',
+      example: '#3B82F6',
     }),
     is_public: z.boolean().openapi({
       description: 'Whether the practice details are publicly visible',
@@ -390,6 +395,7 @@ const practiceDetailsResponseSchema = z
     website: z.string().nullable().openapi({ example: 'https://example.com' }),
     intro_message: z.string().nullable().openapi({ example: 'Welcome' }),
     overview: z.string().nullable().openapi({ example: 'Overview text' }),
+    accent_color: z.string().nullable().openapi({ example: '#3B82F6' }),
     is_public: z.boolean().openapi({ example: true }),
     organization_id: z.string().uuid().openapi({
       description: 'Organization UUID for the practice',

--- a/src/shared/database/migrations/0031_add_accent_color_to_practice_details.sql
+++ b/src/shared/database/migrations/0031_add_accent_color_to_practice_details.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "practice_details" ADD COLUMN "accent_color" text;


### PR DESCRIPTION
- Add accent_color column to practice_details table
- Update validation schemas to include accent_color field
- Update practice service to handle accent_color in create/update operations
- Add accent_color to all practice API responses
- Create database migration for new column
- Enable practice-wide theming while keeping user preferences intact

API endpoints updated:
- POST /api/practice (create)
- PUT /api/practice/:uuid (update)
- GET /api/practice/:uuid (get by ID)
- GET /api/practice/details/:slug (public for widget)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accent color customization for practice profiles. Users can now optionally set and manage an accent color when creating or updating their practice details. The accent color is an optional field that is fully validated and persistently stored. This new field is included in all practice detail API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->