### PR TITLE
fix: update intake GET routes to return income and household_size

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "start": "node dist/hono-server.js",
     "start:all": "concurrently \"pnpm start\" \"pnpm run event-worker\" \"pnpm run email-worker\" --names \"API,EVENT,EMAIL\" --prefix-colors \"blue,green,magenta\"",
     "test": "cross-env APP_ENV=test TS_NODE_FILES=true tap test/**/*.test.ts",
-    "typecheck": "tsc -noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.980.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint:fix": "oxlint --fix",
     "start": "node dist/hono-server.js",
     "start:all": "concurrently \"pnpm start\" \"pnpm run event-worker\" \"pnpm run email-worker\" --names \"API,EVENT,EMAIL\" --prefix-colors \"blue,green,magenta\"",
-    "test": "cross-env TS_NODE_FILES=true tap test/**/*.test.ts",
+    "test": "cross-env APP_ENV=test TS_NODE_FILES=true tap test/**/*.test.ts",
     "typecheck": "tsc -noEmit"
   },
   "dependencies": {

--- a/scripts/initialize-user-preferences.ts
+++ b/scripts/initialize-user-preferences.ts
@@ -69,7 +69,7 @@ const main = async (): Promise<void> => {
 
     // Get users who already have preferences
     const usersWithPreferences = await db
-      .select({ userId: preferences.userId })
+      .select({ userId: preferences.user_id })
       .from(preferences);
 
     const userIdsWithPreferences = new Set(usersWithPreferences.map(p => p.userId));
@@ -114,7 +114,7 @@ const main = async (): Promise<void> => {
       for (const user of batch) {
         try {
           await db.insert(preferences).values({
-            userId: user.id,
+            user_id: user.id,
             notifications: DEFAULT_NOTIFICATION_PREFERENCES,
             general: {},
             security: {},

--- a/scripts/sync-stripe-subscriptions.ts
+++ b/scripts/sync-stripe-subscriptions.ts
@@ -1,0 +1,145 @@
+import { config } from '@dotenvx/dotenvx';
+config();
+import { eq, isNotNull } from 'drizzle-orm';
+import { subscriptions } from '@/schema/better-auth-schema';
+import { db } from '@/shared/database';
+import { stripe } from '@/shared/utils/stripe-client';
+
+const logger = {
+  info: (msg: string, ...args: unknown[]) => console.log(`[INFO] ${msg}`, ...args),
+  error: (msg: string, ...args: unknown[]) => console.error(`[ERROR] ${msg}`, ...args),
+};
+
+/**
+ * Sync Stripe Subscriptions Script
+ *
+ * This script fetches all local subscriptions that have a Stripe Subscription ID,
+ * queries Stripe for their current status, and updates the local database if there are discrepancies.
+ *
+ * Usage:
+ *   npx tsx src/scripts/sync-stripe-subscriptions.ts [--dry-run]
+ */
+
+async function main() {
+  const args = process.argv.slice(2);
+  const isDryRun = args.includes('--dry-run');
+
+  logger.info(`Starting Stripe subscription sync... ${isDryRun ? '(DRY RUN)' : ''}`);
+
+  try {
+    // Fetch all subscriptions with a stripe_subscription_id
+    const localSubscriptions = await db
+      .select()
+      .from(subscriptions)
+      .where(isNotNull(subscriptions.stripeSubscriptionId));
+
+    logger.info(`Found ${localSubscriptions.length} subscriptions with Stripe IDs.`);
+
+    let updatedCount = 0;
+    let errorCount = 0;
+
+    for (const sub of localSubscriptions) {
+      if (!sub.stripeSubscriptionId) continue;
+
+      try {
+        const stripeSub = await stripe.subscriptions.retrieve(sub.stripeSubscriptionId);
+
+        const updates: Partial<typeof subscriptions.$inferInsert> = {};
+        const changes: string[] = [];
+
+        // Check Status
+        if (stripeSub.status !== sub.status) {
+          updates.status = stripeSub.status;
+          changes.push(`Status: ${sub.status} -> ${stripeSub.status}`);
+        }
+
+        // Check Period Start
+        const stripePeriodStart = new Date(stripeSub.current_period_start * 1000);
+        if (stripePeriodStart.getTime() !== sub.periodStart?.getTime()) {
+          updates.periodStart = stripePeriodStart;
+          changes.push(`Period Start: ${sub.periodStart?.toISOString()} -> ${stripePeriodStart.toISOString()}`);
+        }
+
+        // Check Period End
+        const stripePeriodEnd = new Date(stripeSub.current_period_end * 1000);
+        if (stripePeriodEnd.getTime() !== sub.periodEnd?.getTime()) {
+          updates.periodEnd = stripePeriodEnd;
+          changes.push(`Period End: ${sub.periodEnd?.toISOString()} -> ${stripePeriodEnd.toISOString()}`);
+        }
+
+        // Check Cancel At Period End
+        if (stripeSub.cancel_at_period_end !== sub.cancelAtPeriodEnd) {
+          updates.cancelAtPeriodEnd = stripeSub.cancel_at_period_end;
+          changes.push(`Cancel At Period End: ${sub.cancelAtPeriodEnd} -> ${stripeSub.cancel_at_period_end}`);
+        }
+
+        // Check Plan (Price ID)
+        // Note: Stripe subscription items[0].price.id corresponds to our 'plan' field
+        // which stores the price ID/plan name
+        // This mapping might depend on how 'plan' is stored. Assuming it stores the price ID or product ID.
+        // For now, let's log if there's a mismatch but be careful about auto-updating if the mapping is complex.
+        const stripePriceId = stripeSub.items.data[0]?.price.id;
+        if (stripePriceId && sub.plan !== stripePriceId) {
+          // If local plan is not the price ID, checking this might be noisy.
+          // Let's assume for now we only update status/dates.
+          // Uncomment if plan field strictly holds price_id
+          // updates.plan = stripePriceId;
+          // changes.push(`Plan: ${sub.plan} -> ${stripePriceId}`);
+        }
+
+        if (Object.keys(updates).length > 0) {
+          if (isDryRun) {
+            logger.info(`[DRY RUN] Would update subscription ${sub.id} (${sub.stripeSubscriptionId}): ${changes.join(', ')}`);
+          } else {
+            await db
+              .update(subscriptions)
+              .set({
+                ...updates,
+                updatedAt: new Date(),
+              })
+              .where(eq(subscriptions.id, sub.id));
+            logger.info(`Updated subscription ${sub.id} (${sub.stripeSubscriptionId}): ${changes.join(', ')}`);
+            updatedCount++;
+          }
+        }
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+
+        // Handle missing subscription in Stripe
+        if (errorMessage.includes('No such subscription')) {
+          if (sub.status !== 'canceled') {
+            const updates: Partial<typeof subscriptions.$inferInsert> = {
+              status: 'canceled',
+              cancelAtPeriodEnd: false,
+              updatedAt: new Date()
+            };
+
+            if (isDryRun) {
+              logger.info(`[DRY RUN] Subscription ${sub.id} (${sub.stripeSubscriptionId}) not found in Stripe. Would mark as canceled.`);
+            } else {
+              await db.update(subscriptions)
+                .set(updates)
+                .where(eq(subscriptions.id, sub.id));
+              logger.info(`Subscription ${sub.id} (${sub.stripeSubscriptionId}) not found in Stripe. Marked as canceled.`);
+              updatedCount++;
+            }
+          } else {
+            logger.info(`Subscription ${sub.id} (${sub.stripeSubscriptionId}) not found in Stripe. Already canceled locally.`);
+          }
+        } else {
+          logger.error(`Error syncing subscription ${sub.id} (${sub.stripeSubscriptionId}): ${errorMessage}`);
+          errorCount++;
+        }
+      }
+    }
+
+    logger.info(`Sync complete. Updated: ${updatedCount}, Errors: ${errorCount}`);
+  } catch (error) {
+    logger.error('Fatal error during sync:', error);
+    process.exit(1);
+  } finally {
+    process.exit(0);
+  }
+}
+
+main();

--- a/scripts/sync-stripe-subscriptions.ts
+++ b/scripts/sync-stripe-subscriptions.ts
@@ -1,9 +1,9 @@
 import { config } from '@dotenvx/dotenvx';
 config();
 import { eq, isNotNull } from 'drizzle-orm';
-import { subscriptions } from '@/schema/better-auth-schema';
-import { db } from '@/shared/database';
-import { stripe } from '@/shared/utils/stripe-client';
+import { subscriptions } from '../src/schema/better-auth-schema';
+import { db } from '../src/shared/database';
+import { stripe } from '../src/shared/utils/stripe-client';
 
 const logger = {
   info: (msg: string, ...args: unknown[]) => console.log(`[INFO] ${msg}`, ...args),
@@ -17,10 +17,9 @@ const logger = {
  * queries Stripe for their current status, and updates the local database if there are discrepancies.
  *
  * Usage:
- *   npx tsx src/scripts/sync-stripe-subscriptions.ts [--dry-run]
+ *   npx tsx scripts/sync-stripe-subscriptions.ts [--dry-run]
  */
-
-async function main() {
+const main = async function main() {
   const args = process.argv.slice(2);
   const isDryRun = args.includes('--dry-run');
 
@@ -42,26 +41,29 @@ async function main() {
       if (!sub.stripeSubscriptionId) continue;
 
       try {
-        const stripeSub = await stripe.subscriptions.retrieve(sub.stripeSubscriptionId);
+        // The Stripe SDK v20 returns Response<Subscription> which wraps the raw object.
+        // Use record access to bypass strict typing for fields like current_period_start.
+        const stripeResponse = await stripe.subscriptions.retrieve(sub.stripeSubscriptionId);
+        const stripeSub = stripeResponse as unknown as Record<string, unknown>;
 
         const updates: Partial<typeof subscriptions.$inferInsert> = {};
         const changes: string[] = [];
 
         // Check Status
         if (stripeSub.status !== sub.status) {
-          updates.status = stripeSub.status;
+          updates.status = stripeSub.status as string;
           changes.push(`Status: ${sub.status} -> ${stripeSub.status}`);
         }
 
         // Check Period Start
-        const stripePeriodStart = new Date(stripeSub.current_period_start * 1000);
+        const stripePeriodStart = new Date((stripeSub.current_period_start as number) * 1000);
         if (stripePeriodStart.getTime() !== sub.periodStart?.getTime()) {
           updates.periodStart = stripePeriodStart;
           changes.push(`Period Start: ${sub.periodStart?.toISOString()} -> ${stripePeriodStart.toISOString()}`);
         }
 
         // Check Period End
-        const stripePeriodEnd = new Date(stripeSub.current_period_end * 1000);
+        const stripePeriodEnd = new Date((stripeSub.current_period_end as number) * 1000);
         if (stripePeriodEnd.getTime() !== sub.periodEnd?.getTime()) {
           updates.periodEnd = stripePeriodEnd;
           changes.push(`Period End: ${sub.periodEnd?.toISOString()} -> ${stripePeriodEnd.toISOString()}`);
@@ -69,27 +71,15 @@ async function main() {
 
         // Check Cancel At Period End
         if (stripeSub.cancel_at_period_end !== sub.cancelAtPeriodEnd) {
-          updates.cancelAtPeriodEnd = stripeSub.cancel_at_period_end;
+          updates.cancelAtPeriodEnd = stripeSub.cancel_at_period_end as boolean;
           changes.push(`Cancel At Period End: ${sub.cancelAtPeriodEnd} -> ${stripeSub.cancel_at_period_end}`);
-        }
-
-        // Check Plan (Price ID)
-        // Note: Stripe subscription items[0].price.id corresponds to our 'plan' field
-        // which stores the price ID/plan name
-        // This mapping might depend on how 'plan' is stored. Assuming it stores the price ID or product ID.
-        // For now, let's log if there's a mismatch but be careful about auto-updating if the mapping is complex.
-        const stripePriceId = stripeSub.items.data[0]?.price.id;
-        if (stripePriceId && sub.plan !== stripePriceId) {
-          // If local plan is not the price ID, checking this might be noisy.
-          // Let's assume for now we only update status/dates.
-          // Uncomment if plan field strictly holds price_id
-          // updates.plan = stripePriceId;
-          // changes.push(`Plan: ${sub.plan} -> ${stripePriceId}`);
         }
 
         if (Object.keys(updates).length > 0) {
           if (isDryRun) {
-            logger.info(`[DRY RUN] Would update subscription ${sub.id} (${sub.stripeSubscriptionId}): ${changes.join(', ')}`);
+            logger.info(
+              `[DRY RUN] Would update subscription ${sub.id} (${sub.stripeSubscriptionId}): ${changes.join(', ')}`,
+            );
           } else {
             await db
               .update(subscriptions)
@@ -102,29 +92,41 @@ async function main() {
             updatedCount++;
           }
         }
-      } catch (err) {
+      } catch (err: unknown) {
         const errorMessage = err instanceof Error ? err.message : String(err);
 
         // Handle missing subscription in Stripe
-        if (errorMessage.includes('No such subscription')) {
+        const isMissing =
+          (typeof err === 'object' && err !== null && 'code' in err &&
+            (err as Record<string, unknown>).code === 'resource_missing') ||
+          errorMessage.includes('No such subscription');
+
+        if (isMissing) {
           if (sub.status !== 'canceled') {
             const updates: Partial<typeof subscriptions.$inferInsert> = {
               status: 'canceled',
               cancelAtPeriodEnd: false,
-              updatedAt: new Date()
+              updatedAt: new Date(),
             };
 
             if (isDryRun) {
-              logger.info(`[DRY RUN] Subscription ${sub.id} (${sub.stripeSubscriptionId}) not found in Stripe. Would mark as canceled.`);
+              logger.info(
+                `[DRY RUN] Subscription ${sub.id} (${sub.stripeSubscriptionId}) not found in Stripe. Would mark as canceled.`,
+              );
             } else {
-              await db.update(subscriptions)
+              await db
+                .update(subscriptions)
                 .set(updates)
                 .where(eq(subscriptions.id, sub.id));
-              logger.info(`Subscription ${sub.id} (${sub.stripeSubscriptionId}) not found in Stripe. Marked as canceled.`);
+              logger.info(
+                `Subscription ${sub.id} (${sub.stripeSubscriptionId}) not found in Stripe. Marked as canceled.`,
+              );
               updatedCount++;
             }
           } else {
-            logger.info(`Subscription ${sub.id} (${sub.stripeSubscriptionId}) not found in Stripe. Already canceled locally.`);
+            logger.info(
+              `Subscription ${sub.id} (${sub.stripeSubscriptionId}) not found in Stripe. Already canceled locally.`,
+            );
           }
         } else {
           logger.error(`Error syncing subscription ${sub.id} (${sub.stripeSubscriptionId}): ${errorMessage}`);
@@ -140,6 +142,9 @@ async function main() {
   } finally {
     process.exit(0);
   }
-}
+};
 
-main();
+main().catch((err) => {
+  console.error('[ERROR] Unhandled error in main:', err);
+  process.exit(1);
+});

--- a/src/modules/practice-client-intakes/handlers.ts
+++ b/src/modules/practice-client-intakes/handlers.ts
@@ -71,8 +71,8 @@ export const createPracticeClientIntakeCheckoutSessionHandler: AppRouteHandler<
 
 export const updatePracticeClientIntakeHandler: AppRouteHandler<typeof updatePracticeClientIntakeRoute> = async (c) => {
   const { uuid } = c.req.valid('param');
-  const { amount } = c.req.valid('json');
-  const result = await practiceClientIntakesService.updatePracticeClientIntake(uuid, amount);
+  const body = c.req.valid('json');
+  const result = await practiceClientIntakesService.updatePracticeClientIntake(uuid, body);
   return response.fromResult(c, result);
 };
 

--- a/src/modules/practice-client-intakes/routes.ts
+++ b/src/modules/practice-client-intakes/routes.ts
@@ -134,7 +134,7 @@ export const createPracticeClientIntakeRoute = createRoute({
   path: '/create',
   tags: ['Practice Client Intakes'],
   summary: 'Create practice client intake',
-  description: 'Creates a Stripe Payment Link for a practice client intake. The client is redirected to the returned `payment_link_url` to complete payment on Stripe\'s hosted payment page. All endpoints are public (no authentication required).',
+  description: "Creates a Stripe Payment Link for a practice client intake. The client is redirected to the returned `payment_link_url` to complete payment on Stripe's hosted payment page. All endpoints are public (no authentication required). Can include optional fields for case triage such as urgency, desired outcome, court date, etc.",
   request: {
     body: {
       content: {
@@ -181,7 +181,7 @@ export const updatePracticeClientIntakeRoute = createRoute({
   path: '/{uuid}',
   tags: ['Practice Client Intakes'],
   summary: 'Update practice client intake',
-  description: 'Updates the payment amount for a practice client intake by creating a new Stripe Payment Link and deactivating the old one. The UUID is obtained from the create endpoint response. Only works if the payment has not been completed or expired. Returns a new `payment_link_url` for the client to complete payment with the updated amount.',
+  description: 'Updates the payment amount for a practice client intake by creating a new Stripe Payment Link and deactivating the old one. The UUID is obtained from the create endpoint response. Only works if the payment has not been completed or expired. Returns a new `payment_link_url` for the client to complete payment with the updated amount. Can also update optional fields for case triage such as urgency, desired outcome, court date, etc.',
   request: {
     params: uuidParamOpenAPISchema,
     body: {

--- a/src/modules/practice-client-intakes/routes.ts
+++ b/src/modules/practice-client-intakes/routes.ts
@@ -181,7 +181,7 @@ export const updatePracticeClientIntakeRoute = createRoute({
   path: '/{uuid}',
   tags: ['Practice Client Intakes'],
   summary: 'Update practice client intake',
-  description: 'Updates the payment amount for a practice client intake by creating a new Stripe Payment Link and deactivating the old one. The UUID is obtained from the create endpoint response. Only works if the payment has not been completed or expired. Returns a new `payment_link_url` for the client to complete payment with the updated amount. Can also update optional fields for case triage such as urgency, desired outcome, court date, etc.',
+  description: 'Updates practice client intake details in the database. Can update fields for case triage such as urgency, desired outcome, court date, etc. Returns success status.',
   request: {
     params: uuidParamOpenAPISchema,
     body: {
@@ -199,7 +199,7 @@ export const updatePracticeClientIntakeRoute = createRoute({
           schema: intakeValidations.updatePracticeClientIntakeResponseSchema,
         },
       },
-      description: 'Practice client intake updated successfully. Returns the intake UUID, new Stripe Payment Link URL (old link is deactivated), updated payment amount, currency, and status. The new `payment_link_url` should be used to redirect the client to Stripe\'s hosted payment page with the updated amount.',
+      description: 'Intake updated successfully.',
     },
     400: {
       content: {
@@ -431,7 +431,7 @@ export const listIntakesRoute = createRoute({
   path: '/{practice_id}',
   tags: ['Practice Client Intakes'],
   summary: 'List practice client intakes or get by ID',
-  description: 'Retrieves a paginated list of client intakes for a specific practice. Includes filtering by status, search (name/email/opposing party), and date range. Use the `intake_id` query parameter to retrieve a specific intake. Privacy-sensitive fields (income, household_size) are excluded from this response.',
+  description: 'Retrieves a paginated list of client intakes for a specific practice. Includes filtering by status, search (name/email/opposing party), and date range. Use the `intake_id` query parameter to retrieve a specific intake.',
   request: {
     params: z.object({
       practice_id: z.uuid().openapi({

--- a/src/modules/practice-client-intakes/services/practice-client-intakes.service.ts
+++ b/src/modules/practice-client-intakes/services/practice-client-intakes.service.ts
@@ -402,6 +402,11 @@ const updatePracticeClientIntake = async (
       ...(court_date && { court_date: new Date(court_date) }),
     };
 
+    const existingIntake = await practiceClientIntakesRepository.findById(uuid);
+    if (!existingIntake) {
+      return result.notFound(`Practice client intake with UUID '${uuid}' not found`);
+    }
+
     await practiceClientIntakesRepository.update(uuid, dataToUpdate);
 
     return result.ok({ success: true, message: 'Intake updated successfully.' });

--- a/src/modules/practice-client-intakes/services/practice-client-intakes.service.ts
+++ b/src/modules/practice-client-intakes/services/practice-client-intakes.service.ts
@@ -89,6 +89,8 @@ const formatIntakeResponse = (
     desired_outcome: intake.desired_outcome ?? null,
     court_date: intake.court_date?.toISOString() ?? null,
     has_documents: intake.has_documents ?? null,
+    income: intake.income ?? null,
+    household_size: intake.household_size ?? null,
     case_strength: intake.case_strength ?? null,
   };
 };
@@ -321,6 +323,14 @@ const createPracticeClientIntake = async (
         },
         client_ip: request.clientIp,
         user_agent: request.userAgent,
+        // AI & Triage Fields
+        urgency: request.urgency,
+        desired_outcome: request.desired_outcome,
+        court_date: request.court_date ? new Date(request.court_date) : undefined,
+        has_documents: request.has_documents,
+        income: request.income,
+        household_size: request.household_size,
+        case_strength: request.case_strength,
       };
 
       return await practiceClientIntakesRepository.create(practiceClientIntakeData, tx);
@@ -353,6 +363,13 @@ const createPracticeClientIntake = async (
           name: organization.name,
           logo: organization.logo ?? undefined,
         },
+        urgency: request.urgency,
+        desired_outcome: request.desired_outcome,
+        court_date: request.court_date,
+        has_documents: request.has_documents,
+        income: request.income,
+        household_size: request.household_size,
+        case_strength: request.case_strength,
       },
     });
   } catch (error) {
@@ -366,10 +383,32 @@ const createPracticeClientIntake = async (
  * Note: Payment Links cannot be updated directly. This creates a new Payment Link with the updated amount.
  */
 const updatePracticeClientIntake = async (
-  _uuid: string,
-  _amount: number,
-): Promise<Result<void>> => {
-  return result.badRequest('Updating practice client intakes is no longer supported. Create a new intake instead.');
+  uuid: string,
+  body: z.infer<typeof intakeValidations.updatePracticeClientIntakeSchema>,
+): Promise<Result<{ success: boolean; message: string }>> => {
+  try {
+    const { amount, ...updateData } = body;
+
+    const fieldsToUpdate = Object.keys(updateData);
+    if (fieldsToUpdate.length === 0) {
+      return result.badRequest('No fields to update provided.');
+    }
+
+    const { court_date, ...restUpdateData } = updateData;
+
+    const dataToUpdate: Partial<SelectPracticeClientIntake> = {
+      amount,
+      ...restUpdateData,
+      ...(court_date && { court_date: new Date(court_date) }),
+    };
+
+    await practiceClientIntakesRepository.update(uuid, dataToUpdate);
+
+    return result.ok({ success: true, message: 'Intake updated successfully.' });
+  } catch (error) {
+    logger.error('Failed to update practice client intake for {uuid}: {error}', { error, uuid });
+    return result.internalError('Failed to update practice client intake');
+  }
 };
 
 /**

--- a/src/modules/practice-client-intakes/services/practice-client-intakes.service.ts
+++ b/src/modules/practice-client-intakes/services/practice-client-intakes.service.ts
@@ -387,18 +387,11 @@ const updatePracticeClientIntake = async (
   body: z.infer<typeof intakeValidations.updatePracticeClientIntakeSchema>,
 ): Promise<Result<{ success: boolean; message: string }>> => {
   try {
-    const { amount, ...updateData } = body;
-
-    const fieldsToUpdate = Object.keys(updateData);
-    if (fieldsToUpdate.length === 0) {
-      return result.badRequest('No fields to update provided.');
-    }
-
-    const { court_date, ...restUpdateData } = updateData;
+    const { amount, court_date, ...restUpdateData } = body;
 
     const dataToUpdate: Partial<SelectPracticeClientIntake> = {
-      amount,
       ...restUpdateData,
+      ...(typeof amount !== 'undefined' && { amount }),
       ...(court_date && { court_date: new Date(court_date) }),
     };
 

--- a/src/modules/practice-client-intakes/services/practice-client-intakes.service.ts
+++ b/src/modules/practice-client-intakes/services/practice-client-intakes.service.ts
@@ -388,12 +388,15 @@ const updatePracticeClientIntake = async (
 ): Promise<Result<{ success: boolean; message: string }>> => {
   try {
     const { amount, court_date, ...restUpdateData } = body;
-
     const dataToUpdate: Partial<SelectPracticeClientIntake> = {
       ...restUpdateData,
       ...(typeof amount !== 'undefined' && { amount }),
       ...(court_date && { court_date: new Date(court_date) }),
     };
+
+    if (Object.keys(dataToUpdate).length === 0) {
+      return result.badRequest('No fields to update provided.');
+    }
 
     const existingIntake = await practiceClientIntakesRepository.findById(uuid);
     if (!existingIntake) {

--- a/src/modules/practice-client-intakes/validations/practice-client-intakes.validation.ts
+++ b/src/modules/practice-client-intakes/validations/practice-client-intakes.validation.ts
@@ -32,7 +32,7 @@ const createPracticeClientIntakeSchema = z.object({
 });
 
 const updatePracticeClientIntakeSchema = z.object({
-  amount: z.number().int().min(50).max(99999999),
+  amount: z.number().int().min(50).max(99999999).optional(),
   urgency: z.enum(['routine', 'time_sensitive', 'emergency']).optional(),
   desired_outcome: z.string().optional(),
   court_date: z.iso.datetime().optional(),
@@ -158,8 +158,8 @@ const practiceClientIntakeStatusResponseSchema = z.object({
     desired_outcome: z.string().optional(),
     court_date: z.iso.datetime().optional(),
     has_documents: z.boolean().optional(),
-    income: z.number().int().optional(),
-    household_size: z.number().int().optional(),
+    income: z.number().int().nullable(),
+    household_size: z.number().int().nullable(),
     case_strength: z.number().optional(),
   }).optional(),
   error: z.string().optional(),

--- a/src/modules/practice-client-intakes/validations/practice-client-intakes.validation.ts
+++ b/src/modules/practice-client-intakes/validations/practice-client-intakes.validation.ts
@@ -22,10 +22,24 @@ const createPracticeClientIntakeSchema = z.object({
     description: 'Conversation ID associated with the client intake',
     example: '123e4567-e89b-12d3-a456-426614174000',
   }),
+  urgency: z.enum(['routine', 'time_sensitive', 'emergency']).optional(),
+  desired_outcome: z.string().optional(),
+  court_date: z.iso.datetime().optional(),
+  has_documents: z.boolean().optional(),
+  income: z.number().int().optional(),
+  household_size: z.number().int().optional(),
+  case_strength: z.number().min(0).max(1).optional(),
 });
 
 const updatePracticeClientIntakeSchema = z.object({
   amount: z.number().int().min(50).max(99999999),
+  urgency: z.enum(['routine', 'time_sensitive', 'emergency']).optional(),
+  desired_outcome: z.string().optional(),
+  court_date: z.iso.datetime().optional(),
+  has_documents: z.boolean().optional(),
+  income: z.number().int().optional(),
+  household_size: z.number().int().optional(),
+  case_strength: z.number().min(0).max(1).optional(),
 });
 
 const slugParamSchema = z.object({
@@ -78,6 +92,13 @@ const createPracticeClientIntakeResponseSchema = z.object({
       name: z.string(),
       logo: z.string().optional(),
     }),
+    urgency: z.enum(['routine', 'time_sensitive', 'emergency']).optional(),
+    desired_outcome: z.string().optional(),
+    court_date: z.iso.datetime().optional(),
+    has_documents: z.boolean().optional(),
+    income: z.number().int().optional(),
+    household_size: z.number().int().optional(),
+    case_strength: z.number().min(0).max(1).optional(),
   }).optional(),
   error: z.string().optional(),
 });
@@ -93,14 +114,7 @@ const createPracticeClientIntakeCheckoutSessionResponseSchema = z.object({
 
 const updatePracticeClientIntakeResponseSchema = z.object({
   success: z.boolean(),
-  data: z.object({
-    uuid: z.uuid(),
-    payment_link_url: z.url(),
-    amount: z.number(),
-    currency: z.string(),
-    status: z.string(),
-  }).optional(),
-  error: z.string().optional(),
+  message: z.string(),
 });
 
 const practiceClientIntakeStatusResponseSchema = z.object({
@@ -144,6 +158,8 @@ const practiceClientIntakeStatusResponseSchema = z.object({
     desired_outcome: z.string().optional(),
     court_date: z.iso.datetime().optional(),
     has_documents: z.boolean().optional(),
+    income: z.number().int().optional(),
+    household_size: z.number().int().optional(),
     case_strength: z.number().optional(),
   }).optional(),
   error: z.string().optional(),
@@ -216,6 +232,8 @@ const listIntakesResponseSchema = z.object({
       case_strength: z.number().nullable(),
       desired_outcome: z.string().nullable(),
       has_documents: z.boolean().nullable(),
+      income: z.number().int().nullable(),
+      household_size: z.number().int().nullable(),
       metadata: z.object({
         email: z.string(),
         name: z.string(),

--- a/src/modules/preferences/schema/preferences.schema.ts
+++ b/src/modules/preferences/schema/preferences.schema.ts
@@ -8,16 +8,13 @@
 import { relations } from 'drizzle-orm';
 import {
   pgTable,
-  text,
   timestamp,
-  date,
   index,
   uuid,
   jsonb,
 } from 'drizzle-orm/pg-core';
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
 import { z } from 'zod';
-import { users } from '@/schema/better-auth-schema';
 import type {
   GeneralPreferences,
   NotificationPreferences,
@@ -27,6 +24,7 @@ import type {
   ProductUsage,
 } from '@/modules/preferences/types/preferences.types';
 import { PRODUCT_USAGE_OPTIONS } from '@/modules/preferences/types/preferences.types';
+import { users } from '@/schema/better-auth-schema';
 
 // Zod schema for product usage validation
 const productUsageSchema = z.array(

--- a/src/shared/services/email/email.service.ts
+++ b/src/shared/services/email/email.service.ts
@@ -13,6 +13,7 @@ import { db } from '@/shared/database/connection';
 import { appConfigService } from '@/shared/services/app-config.service';
 import { emailLogs } from '@/shared/services/email/schemas/email-logs.schema';
 import { renderTemplate, type TemplateDataMap } from '@/shared/services/email/templates';
+import { isProduction, isTest } from '@/shared/utils/env';
 
 const logger = getLogger(['shared', 'services', 'email']);
 
@@ -38,7 +39,7 @@ const DEFAULT_FROM_NAME = 'Blawby';
  * Save email to local file for development preview
  */
 const saveEmailToFile = (to: string, subject: string, html: string) => {
-  if (process.env.NODE_ENV === 'production') return;
+  if (isProduction()) return;
 
   try {
     const storageDir = path.join(process.cwd(), 'storage', 'emails');
@@ -81,18 +82,26 @@ export const sendEmail = async (
       payload.data as unknown as TemplateDataMap[EmailTemplateName],
     );
 
-    // Development: Save to file for instant preview
-    if (process.env.NODE_ENV !== 'production') {
+    // Development/Test: Save to file for instant preview
+    if (!isProduction()) {
       saveEmailToFile(payload.to, payload.subject, html);
     }
 
     // Send via Resend
     const apiKey = process.env.RESEND_API_KEY;
-    const isLocal = process.env.NODE_ENV !== 'production';
+    const isProdLike = isProductionLike();
+    const isTestMode = isTest();
 
-    // Skip actual sending if no API key in dev
-    if (isLocal && (!apiKey || apiKey === 'fake' || apiKey.startsWith('re_your_'))) {
-      logger.info('📡 [DEV] Skipping actual Resend call for "{subject}". Local preview saved.', {
+    // Skip actual sending if:
+    // 1. Not in production/staging
+    // 2. OR no valid API key
+    // 3. OR specifically in test mode
+    const shouldSkip = !isProdLike || !apiKey || apiKey === 'fake' || apiKey.startsWith('re_your_') || isTestMode;
+
+    if (shouldSkip) {
+      const reason = isTestMode ? 'TEST' : (!isProdLike ? 'DEV' : 'NO_API_KEY');
+      logger.info('📡 [{reason}] Skipping actual Resend call for "{subject}". Local preview saved.', {
+        reason,
         subject: payload.subject,
       });
 
@@ -103,10 +112,10 @@ export const sendEmail = async (
         templateName: payload.template,
         templateData: payload.data,
         status: 'sent',
-        messageId: 'local_preview_' + Date.now(),
+        messageId: `${reason.toLowerCase()}_preview_${Date.now()}`,
       }).catch((err) => logger.error('Failed to log email success to database: {error}', { error: err }));
 
-      return { success: true, messageId: 'local_preview' };
+      return { success: true, messageId: `${reason.toLowerCase()}_preview` };
     }
 
     // Get "from" details from app config

--- a/src/shared/services/email/email.service.ts
+++ b/src/shared/services/email/email.service.ts
@@ -13,7 +13,7 @@ import { db } from '@/shared/database/connection';
 import { appConfigService } from '@/shared/services/app-config.service';
 import { emailLogs } from '@/shared/services/email/schemas/email-logs.schema';
 import { renderTemplate, type TemplateDataMap } from '@/shared/services/email/templates';
-import { isProduction, isTest } from '@/shared/utils/env';
+import { isProduction, isTest, isProductionLike } from '@/shared/utils/env';
 
 const logger = getLogger(['shared', 'services', 'email']);
 

--- a/src/shared/utils/env.ts
+++ b/src/shared/utils/env.ts
@@ -17,21 +17,12 @@ type NodeEnvironment = 'development' | 'production';
  */
 export const getAppEnv = (): AppEnvironment => {
   const appEnv = process.env.APP_ENV?.toLowerCase();
-  const nodeEnv = process.env.NODE_ENV?.toLowerCase();
+
 
   if (appEnv === 'development' || appEnv === 'staging' || appEnv === 'production' || appEnv === 'test') {
     return appEnv;
   }
 
-  // Fallback to NODE_ENV
-  if (nodeEnv === 'development' || nodeEnv === 'production') {
-    return nodeEnv;
-  }
-
-  // Special fallback for NODE_ENV=test
-  if (nodeEnv === 'test') {
-    return 'test';
-  }
 
   // Default to development
   return 'development';

--- a/src/shared/utils/env.ts
+++ b/src/shared/utils/env.ts
@@ -8,7 +8,7 @@
  * - APP_ENV: Used by application logic ('development' | 'staging' | 'production')
  */
 
-type AppEnvironment = 'development' | 'staging' | 'production';
+type AppEnvironment = 'development' | 'staging' | 'production' | 'test';
 type NodeEnvironment = 'development' | 'production';
 
 /**
@@ -19,13 +19,18 @@ export const getAppEnv = (): AppEnvironment => {
   const appEnv = process.env.APP_ENV?.toLowerCase();
   const nodeEnv = process.env.NODE_ENV?.toLowerCase();
 
-  if (appEnv === 'development' || appEnv === 'staging' || appEnv === 'production') {
+  if (appEnv === 'development' || appEnv === 'staging' || appEnv === 'production' || appEnv === 'test') {
     return appEnv;
   }
 
   // Fallback to NODE_ENV
   if (nodeEnv === 'development' || nodeEnv === 'production') {
     return nodeEnv;
+  }
+
+  // Special fallback for NODE_ENV=test
+  if (nodeEnv === 'test') {
+    return 'test';
   }
 
   // Default to development
@@ -45,6 +50,13 @@ export const getNodeEnv = (): NodeEnvironment => {
  */
 export const isDevelopment = (): boolean => {
   return getAppEnv() === 'development';
+};
+
+/**
+ * Check if running in test environment
+ */
+export const isTest = (): boolean => {
+  return getAppEnv() === 'test';
 };
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -69,8 +69,7 @@
     }
   },
   "include": [
-    "src/**/*.ts",
-    "scripts/**/*.ts"
+    "src/**/*.ts"
   ],
   "exclude": [
     "node_modules",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -69,7 +69,8 @@
     }
   },
   "include": [
-    "src/**/*.ts"
+    "src/**/*.ts",
+    "scripts/**/*.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intake creation and responses now surface optional triage fields (urgency, desired outcome, court date, has documents, income, household size, case strength).

* **Improvements**
  * Intake updates accept full payloads with validation and return clear success messages.
  * Email preview/sending now treats test/dev similarly and labels preview reasons (TEST/DEV/NO_API_KEY).
  * App recognizes a dedicated test environment.

* **Tools**
  * Added a script to sync local subscriptions with Stripe.
* **Chore**
  * Test runner env and project config updated to include scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->