### PR TITLE
Refactor matter handlers and routes to support new task listing feature

### DIFF
--- a/src/modules/matters/handlers.ts
+++ b/src/modules/matters/handlers.ts
@@ -290,7 +290,11 @@ const reorderMilestonesHandler: AppRouteHandler<typeof matterRoutes.reorderMiles
 };
 
 
-const listMatterTasksHandler: AppRouteHandler<typeof matterRoutes.listMatterTasksRoute> = (c) => {
+const listMatterTasksHandler: AppRouteHandler<typeof matterRoutes.listMatterTasksRoute> = async (c) => {
+  const ctx = getServiceContext(c);
+  const { id: matterId } = c.req.valid('param');
+  const accessResult = await mattersService.verifyMatterAccess(matterId, ctx);
+  if (!accessResult.success) return response.fromResult(c, accessResult);
   return c.json({ error: 'Matter tasks are not yet implemented' }, 501);
 };
 

--- a/src/modules/matters/handlers.ts
+++ b/src/modules/matters/handlers.ts
@@ -22,25 +22,24 @@ const getMattersHandler: AppRouteHandler<typeof matterRoutes.getMattersRoute> = 
   const ctx = getServiceContext(c);
   const query = c.req.valid('query');
 
-  const result = await mattersService.listMatters(
-    {
-      ...query,
-      page: parseInt(String(query.page ?? '1'), 10),
-      limit: parseInt(String(query.limit ?? '20'), 10),
-    },
-    ctx,
-  );
-
-  if (!result.success) {
-    return response.fromResult(c, result);
+  if (query.matter_id) {
+    const result = await mattersService.getMatterById(query.matter_id, ctx);
+    if (!result.success) return response.fromResult(c, result);
+    return response.ok(c, { matter: result.data });
   }
+
+  const page = parseInt(String(query.page ?? '1'), 10);
+  const limit = parseInt(String(query.limit ?? '20'), 10);
+  const result = await mattersService.listMatters({ ...query, page, limit }, ctx);
+
+  if (!result.success) return response.fromResult(c, result);
 
   return response.ok(c, {
     matters: result.data.matters,
     total: result.data.total,
-    page: parseInt(String(query.page ?? '1'), 10),
-    limit: parseInt(String(query.limit ?? '20'), 10),
-    totalPages: Math.ceil(result.data.total / parseInt(String(query.limit ?? '20'), 10)),
+    page,
+    limit,
+    totalPages: Math.ceil(result.data.total / limit),
   });
 };
 
@@ -291,6 +290,10 @@ const reorderMilestonesHandler: AppRouteHandler<typeof matterRoutes.reorderMiles
 };
 
 
+const listMatterTasksHandler: AppRouteHandler<typeof matterRoutes.listMatterTasksRoute> = (c) => {
+  return c.json({ error: 'Matter tasks are not yet implemented' }, 501);
+};
+
 export const handlers = {
   getMattersHandler,
   createMatterHandler,
@@ -315,4 +318,5 @@ export const handlers = {
   createMatterNoteHandler,
   updateMatterNoteHandler,
   deleteMatterNoteHandler,
+  listMatterTasksHandler,
 };

--- a/src/modules/matters/http.ts
+++ b/src/modules/matters/http.ts
@@ -16,6 +16,7 @@ app.openapi(matterRoutes.getMattersRoute, matterHandlers.getMattersHandler);
 app.openapi(matterRoutes.updateMatterRoute, matterHandlers.updateMatterHandler);
 app.openapi(matterRoutes.deleteMatterRoute, matterHandlers.deleteMatterHandler);
 app.openapi(matterRoutes.getMatterActivityRoute, matterHandlers.getMatterActivityHandler);
+app.openapi(matterRoutes.listMatterTasksRoute, matterHandlers.listMatterTasksHandler);
 
 // Notes
 app.openapi(matterRoutes.listMatterNotesRoute, matterHandlers.listMatterNotesHandler);

--- a/src/modules/matters/routes/core.routes.ts
+++ b/src/modules/matters/routes/core.routes.ts
@@ -47,7 +47,8 @@ export const getMattersRoute = routeBuilder.build({
   method: 'get',
   path: '/{practice_id}/matters',
   tags,
-  summary: 'List matters',
+  summary: 'Get matters',
+  description: 'Returns a single matter when `matter_id` is provided, otherwise returns a paginated list.',
   request: {
     params: z.object({
       practice_id: z.uuid(),
@@ -56,16 +57,27 @@ export const getMattersRoute = routeBuilder.build({
   },
   responses: {
     200: {
-      description: 'Matters retrieved successfully',
+      description: 'Matter(s) retrieved successfully',
       content: {
         'application/json': {
-          schema: z.object({
-            matters: z.array(matterResponseSchema),
-            total: z.number(),
-            page: z.number(),
-            limit: z.number(),
-            totalPages: z.number(),
-          }),
+          schema: z.union([
+            z.object({ matter: matterResponseSchema }),
+            z.object({
+              matters: z.array(matterResponseSchema),
+              total: z.number(),
+              page: z.number(),
+              limit: z.number(),
+              totalPages: z.number(),
+            }),
+          ]),
+        },
+      },
+    },
+    404: {
+      description: 'Matter not found',
+      content: {
+        'application/json': {
+          schema: errorResponseSchema,
         },
       },
     },

--- a/src/modules/matters/routes/index.ts
+++ b/src/modules/matters/routes/index.ts
@@ -5,7 +5,6 @@ import {
   updateMatterRoute,
   deleteMatterRoute,
 } from '@/modules/matters/routes/core.routes';
-import { listMatterTasksRoute } from '@/modules/matters/routes/tasks.routes';
 import {
   listExpensesRoute,
   createExpenseRoute,
@@ -25,6 +24,7 @@ import {
   updateMatterNoteRoute,
   deleteMatterNoteRoute,
 } from '@/modules/matters/routes/notes.routes';
+import { listMatterTasksRoute } from '@/modules/matters/routes/tasks.routes';
 import {
   listTimeEntriesRoute,
   createTimeEntryRoute,

--- a/src/modules/matters/routes/index.ts
+++ b/src/modules/matters/routes/index.ts
@@ -5,6 +5,7 @@ import {
   updateMatterRoute,
   deleteMatterRoute,
 } from '@/modules/matters/routes/core.routes';
+import { listMatterTasksRoute } from '@/modules/matters/routes/tasks.routes';
 import {
   listExpensesRoute,
   createExpenseRoute,
@@ -56,4 +57,5 @@ export const routes = {
   updateMilestoneRoute,
   deleteMilestoneRoute,
   reorderMilestonesRoute,
+  listMatterTasksRoute,
 };

--- a/src/modules/matters/routes/tasks.routes.ts
+++ b/src/modules/matters/routes/tasks.routes.ts
@@ -1,0 +1,31 @@
+import { z } from '@hono/zod-openapi';
+import { routeBuilder } from '@/shared/router/route-builder';
+
+const tags = ['Matters'];
+
+const matterIdParamSchema = z.object({
+  practice_id: z.uuid(),
+  id: z.uuid(),
+});
+
+export const listMatterTasksRoute = routeBuilder.build({
+  method: 'get',
+  path: '/{practice_id}/matters/{id}/tasks',
+  tags,
+  summary: 'List matter tasks (not implemented)',
+  request: {
+    params: matterIdParamSchema,
+  },
+  responses: {
+    501: {
+      description: 'Matter tasks are not yet implemented',
+      content: {
+        'application/json': {
+          schema: z.object({
+            error: z.string(),
+          }),
+        },
+      },
+    },
+  },
+});

--- a/src/modules/matters/routes/tasks.routes.ts
+++ b/src/modules/matters/routes/tasks.routes.ts
@@ -17,6 +17,22 @@ export const listMatterTasksRoute = routeBuilder.build({
     params: matterIdParamSchema,
   },
   responses: {
+    200: {
+      description: 'Tasks retrieved successfully',
+      content: {
+        'application/json': {
+          schema: z.object({
+            tasks: z.array(z.object({
+              id: z.uuid(),
+              title: z.string(),
+              status: z.string(),
+              due_date: z.string().nullable().optional(),
+              assigned_to: z.uuid().nullable().optional(),
+            })),
+          }),
+        },
+      },
+    },
     501: {
       description: 'Matter tasks are not yet implemented',
       content: {

--- a/src/modules/matters/services/matter-expenses.service.ts
+++ b/src/modules/matters/services/matter-expenses.service.ts
@@ -32,7 +32,7 @@ const createMatterExpense = async (
   }
 
   // Verify user has access to matter
-  const matterResult = await mattersService.getMatterById(matterId, ctx);
+  const matterResult = await mattersService.verifyMatterAccess(matterId, ctx);
   if (!matterResult.success) {
     return matterResult;
   }
@@ -95,7 +95,7 @@ const listMatterExpenses = async (
   }
 
   // Verify user has access to matter
-  const matterResult = await mattersService.getMatterById(matterId, ctx);
+  const matterResult = await mattersService.verifyMatterAccess(matterId, ctx);
   if (!matterResult.success) {
     return matterResult;
   }
@@ -140,7 +140,7 @@ const updateMatterExpense = async (
   }
 
   // Verify user has access to matter
-  const matterResult = await mattersService.getMatterById(matterId, ctx);
+  const matterResult = await mattersService.verifyMatterAccess(matterId, ctx);
   if (!matterResult.success) {
     return matterResult;
   }
@@ -207,7 +207,7 @@ const deleteMatterExpense = async (
   }
 
   // Verify user has access to matter
-  const matterResult = await mattersService.getMatterById(matterId, ctx);
+  const matterResult = await mattersService.verifyMatterAccess(matterId, ctx);
   if (!matterResult.success) {
     return matterResult;
   }
@@ -268,7 +268,7 @@ const getExpenseStats = async (
   }
 
   // Verify user has access to matter
-  const matterResult = await mattersService.getMatterById(matterId, ctx);
+  const matterResult = await mattersService.verifyMatterAccess(matterId, ctx);
   if (!matterResult.success) {
     return matterResult;
   }

--- a/src/modules/matters/services/matter-milestones.service.ts
+++ b/src/modules/matters/services/matter-milestones.service.ts
@@ -33,7 +33,7 @@ const createMatterMilestone = async (
   }
 
   // Verify user has access to matter
-  const matterResult = await mattersService.getMatterById(matterId, ctx);
+  const matterResult = await mattersService.verifyMatterAccess(matterId, ctx);
   if (!matterResult.success) {
     return matterResult;
   }
@@ -96,7 +96,7 @@ const listMatterMilestones = async (
   }
 
   // Verify user has access to matter
-  const matterResult = await mattersService.getMatterById(matterId, ctx);
+  const matterResult = await mattersService.verifyMatterAccess(matterId, ctx);
   if (!matterResult.success) {
     return matterResult;
   }
@@ -139,7 +139,7 @@ const updateMatterMilestone = async (
   }
 
   // Verify user has access to matter
-  const matterResult = await mattersService.getMatterById(matterId, ctx);
+  const matterResult = await mattersService.verifyMatterAccess(matterId, ctx);
   if (!matterResult.success) {
     return matterResult;
   }
@@ -245,7 +245,7 @@ const deleteMatterMilestone = async (
   }
 
   // Verify user has access to matter
-  const matterResult = await mattersService.getMatterById(matterId, ctx);
+  const matterResult = await mattersService.verifyMatterAccess(matterId, ctx);
   if (!matterResult.success) {
     return matterResult;
   }
@@ -305,7 +305,7 @@ const reorderMilestones = async (
   }
 
   // Verify user has access to matter
-  const matterResult = await mattersService.getMatterById(matterId, ctx);
+  const matterResult = await mattersService.verifyMatterAccess(matterId, ctx);
   if (!matterResult.success) {
     return matterResult;
   }
@@ -375,7 +375,7 @@ const getMilestoneStats = async (
   }
 
   // Verify user has access to matter
-  const matterResult = await mattersService.getMatterById(matterId, ctx);
+  const matterResult = await mattersService.verifyMatterAccess(matterId, ctx);
   if (!matterResult.success) {
     return matterResult;
   }

--- a/src/modules/matters/services/matter-notes.service.ts
+++ b/src/modules/matters/services/matter-notes.service.ts
@@ -29,7 +29,7 @@ const createMatterNote = async (
   }
 
   // Verify user has access to matter
-  const matterResult = await mattersService.getMatterById(matterId, ctx);
+  const matterResult = await mattersService.verifyMatterAccess(matterId, ctx);
   if (!matterResult.success) {
     return matterResult;
   }
@@ -87,7 +87,7 @@ const listMatterNotes = async (
   }
 
   // Verify user has access to matter
-  const matterResult = await mattersService.getMatterById(matterId, ctx);
+  const matterResult = await mattersService.verifyMatterAccess(matterId, ctx);
   if (!matterResult.success) {
     return matterResult;
   }
@@ -130,7 +130,7 @@ const updateMatterNote = async (
   }
 
   // Verify user has access to matter
-  const matterResult = await mattersService.getMatterById(matterId, ctx);
+  const matterResult = await mattersService.verifyMatterAccess(matterId, ctx);
   if (!matterResult.success) {
     return matterResult;
   }
@@ -197,7 +197,7 @@ const deleteMatterNote = async (
   }
 
   // Verify user has access to matter
-  const matterResult = await mattersService.getMatterById(matterId, ctx);
+  const matterResult = await mattersService.verifyMatterAccess(matterId, ctx);
   if (!matterResult.success) {
     return matterResult;
   }

--- a/src/modules/matters/services/matter-time-entries.service.ts
+++ b/src/modules/matters/services/matter-time-entries.service.ts
@@ -52,7 +52,7 @@ const createMatterTimeEntry = async (
   }
 
   // Verify user has access to matter
-  const matterResult = await mattersService.getMatterById(matterId, ctx);
+  const matterResult = await mattersService.verifyMatterAccess(matterId, ctx);
   if (!matterResult.success) {
     return matterResult;
   }
@@ -131,7 +131,7 @@ const listMatterTimeEntries = async (
   }
 
   // Verify user has access to matter
-  const matterResult = await mattersService.getMatterById(matterId, ctx);
+  const matterResult = await mattersService.verifyMatterAccess(matterId, ctx);
   if (!matterResult.success) {
     return matterResult;
   }
@@ -176,7 +176,7 @@ const updateMatterTimeEntry = async (
   }
 
   // Verify user has access to matter
-  const matterResult = await mattersService.getMatterById(matterId, ctx);
+  const matterResult = await mattersService.verifyMatterAccess(matterId, ctx);
   if (!matterResult.success) {
     return matterResult;
   }
@@ -276,7 +276,7 @@ const deleteMatterTimeEntry = async (
   }
 
   // Verify user has access to matter
-  const matterResult = await mattersService.getMatterById(matterId, ctx);
+  const matterResult = await mattersService.verifyMatterAccess(matterId, ctx);
   if (!matterResult.success) {
     return matterResult;
   }
@@ -340,7 +340,7 @@ const getTimeEntryStats = async (
   }
 
   // Verify user has access to matter
-  const matterResult = await mattersService.getMatterById(matterId, ctx);
+  const matterResult = await mattersService.verifyMatterAccess(matterId, ctx);
   if (!matterResult.success) {
     return matterResult;
   }

--- a/src/modules/matters/services/matters.service.ts
+++ b/src/modules/matters/services/matters.service.ts
@@ -153,7 +153,27 @@ const createMatter = async (
 };
 
 /**
- * Get matter by ID
+ * Lightweight access check for sub-resource endpoints (notes, time entries, expenses, milestones).
+ * Uses a minimal DB query — does NOT load relations.
+ */
+const verifyMatterAccess = async (
+  matterId: string,
+  ctx: ServiceContext,
+): Promise<Result<void>> => {
+  const matter = await mattersQueries.findMatterById(matterId);
+
+  if (!matter || matter.organization_id !== ctx.organizationId) {
+    return result.notFound('Matter not found');
+  }
+
+  const forbiddenResult = getForbiddenResult(ctx, 'read', toSubject('Matter', matter));
+  if (forbiddenResult) return forbiddenResult;
+
+  return result.ok();
+};
+
+/**
+ * Get matter by ID (with full relations — for matter detail view only)
  */
 const getMatterById = async (
   matterId: string,
@@ -451,6 +471,7 @@ const getMatterCounts = async (
 export const mattersService = {
   createMatter,
   getMatterById,
+  verifyMatterAccess,
   listMatters,
   updateMatter,
   deleteMatter,


### PR DESCRIPTION
- Updated `getMattersHandler` to return a single matter when `matter_id` is provided, otherwise return a paginated list.
- Introduced `listMatterTasksHandler` with a placeholder response for future implementation.
- Enhanced OpenAPI documentation for `getMattersRoute` to clarify response structure.
- Added new route for listing matter tasks in `tasks.routes.ts` and updated routes index accordingly.
- Replaced `getMatterById` with `verifyMatterAccess` in various services for improved access control checks.
fixes #119 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single-matter fetch supported via existing endpoint.
  * New route to list matter tasks (returns Not Implemented).

* **API Changes**
  * Responses now support either a single matter or a paginated list.
  * Explicit 404 response for missing matters.

* **Refactor**
  * Matter access checks standardized across related flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->