### PR TITLE
fix: remove duplicate relations from better-auth-schema causing build failure

### DIFF
--- a/src/schema/better-auth-schema.ts
+++ b/src/schema/better-auth-schema.ts
@@ -1,4 +1,4 @@
-import { relations, sql } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
 import {
   pgTable,
   text,
@@ -12,7 +12,6 @@ import {
   index,
   uniqueIndex,
 } from 'drizzle-orm/pg-core';
-import { stripeConnectedAccounts } from '@/modules/onboarding/schemas/onboarding.schema';
 
 export const users = pgTable('users', {
   id: uuid('id').primaryKey().defaultRandom(),
@@ -221,71 +220,3 @@ export const identityUpgradeClaims = pgTable(
   ]
 );
 
-// Define relations
-export const usersRelations = relations(users, ({ many }) => ({
-  sessions: many(sessions),
-  accounts: many(accounts),
-  members: many(members),
-  invitations: many(invitations),
-}));
-
-export const organizationsRelations = relations(organizations, ({ many, one }) => ({
-  members: many(members),
-  invitations: many(invitations),
-  stripeConnectedAccounts: many(stripeConnectedAccounts),
-  subscriptions: many(subscriptions, { relationName: 'orgSubscriptions' }),
-  activeSubscription: one(subscriptions, {
-    fields: [organizations.activeSubscriptionId],
-    references: [subscriptions.id],
-    relationName: 'activeSubscription',
-  }),
-}));
-
-export const subscriptionsRelations = relations(subscriptions, ({ one }) => ({
-  organization: one(organizations, {
-    fields: [subscriptions.referenceId],
-    references: [organizations.id],
-    relationName: 'orgSubscriptions',
-  }),
-  activeForOrganization: one(organizations, {
-    fields: [subscriptions.id],
-    references: [organizations.activeSubscriptionId],
-    relationName: 'activeSubscription',
-  }),
-}));
-
-export const sessionsRelations = relations(sessions, ({ one }) => ({
-  user: one(users, {
-    fields: [sessions.userId],
-    references: [users.id],
-  }),
-}));
-
-export const accountsRelations = relations(accounts, ({ one }) => ({
-  user: one(users, {
-    fields: [accounts.userId],
-    references: [users.id],
-  }),
-}));
-
-export const membersRelations = relations(members, ({ one }) => ({
-  user: one(users, {
-    fields: [members.userId],
-    references: [users.id],
-  }),
-  organization: one(organizations, {
-    fields: [members.organizationId],
-    references: [organizations.id],
-  }),
-}));
-
-export const invitationsRelations = relations(invitations, ({ one }) => ({
-  organization: one(organizations, {
-    fields: [invitations.organizationId],
-    references: [organizations.id],
-  }),
-  inviter: one(users, {
-    fields: [invitations.inviterId],
-    references: [users.id],
-  }),
-}));


### PR DESCRIPTION
Relations for users, sessions, accounts, members, invitations, organizations, and subscriptions were defined inline in better-auth-schema.ts AND re-exported from the dedicated better-auth-schema-relations.ts file. The schema barrel index re-exported both, causing TS2308 ambiguous re-export errors that failed the production build.

Removed the inline relations block from better-auth-schema.ts — they are fully covered by better-auth-schema-relations.ts and subscription-relations.schema.ts which are already exported from the barrel index.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed internal database relationship definitions from the schema to streamline the codebase. This is a maintenance update with no impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->