### PR TITLE
fix(practice-client-intakes): add fallback to prevent 503 on invalid checkout session IDs

### DIFF
--- a/src/modules/practice-client-intakes/services/intake-checkout.service.ts
+++ b/src/modules/practice-client-intakes/services/intake-checkout.service.ts
@@ -5,12 +5,8 @@ import { organizationRepository } from '@/modules/practice/database/queries/orga
 import { practiceClientIntakesRepository } from '@/modules/practice-client-intakes/database/queries/practice-client-intakes.repository';
 import { practiceClientIntakesSchema } from '@/modules/practice-client-intakes/database/schema/practice-client-intakes.schema';
 import { getActorAccessibleIntake } from '@/modules/practice-client-intakes/services/intake-access.helpers';
-import {
-  formatIntakeStatusResponse,
-  logger,
-  parseMetadata,
-  resolvePracticeClientIntakeByCheckoutSessionId,
-} from '@/modules/practice-client-intakes/services/intake-shared.helpers';
+import { getLogger } from '@logtape/logtape';
+import { intakeSharedHelpers } from '@/modules/practice-client-intakes/services/intake-shared.helpers';
 import { createIntakeCheckoutSession } from '@/modules/practice-client-intakes/services/intake-stripe.helpers';
 import type {
   ClaimPracticeClientIntakeResponse,
@@ -26,6 +22,8 @@ import { result } from '@/shared/utils/result';
 
 const { practiceClientIntakes } = practiceClientIntakesSchema;
 
+const logger = getLogger(['practice-client-intakes', 'service']);
+
 type ClaimIntakeAbort = {
   __claimIntakeResult: true;
   result: Result<ClaimPracticeClientIntakeResponse>;
@@ -36,7 +34,7 @@ const isClaimIntakeAbort = (value: unknown): value is ClaimIntakeAbort => {
 };
 
 const buildUpdatedMetadata = (ctx: ServiceContext, practiceClientIntake: { metadata: unknown }) => {
-  const baseMetadata = parseMetadata(practiceClientIntake.metadata);
+  const baseMetadata = intakeSharedHelpers.parseMetadata(practiceClientIntake.metadata);
   if (ctx.userId) {
     return {
       ...(baseMetadata ?? { email: '', name: '' }),
@@ -50,7 +48,7 @@ const processClaimIntakeTx = async (
   tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
   intake: NonNullable<
     Extract<
-      Awaited<ReturnType<typeof resolvePracticeClientIntakeByCheckoutSessionId>>,
+      Awaited<ReturnType<typeof intakeSharedHelpers.resolvePracticeClientIntakeByCheckoutSessionId>>,
       { success: true }
     >['data']['intake']
   >,
@@ -84,7 +82,7 @@ const processClaimIntakeTx = async (
     return rollbackWithResult(result.badRequest('Payment must be completed before claiming intake'));
   }
 
-  const intakeMetadata = parseMetadata(lockedIntake.metadata);
+  const intakeMetadata = intakeSharedHelpers.parseMetadata(lockedIntake.metadata);
   if (!intakeMetadata) {
     return rollbackWithResult(result.badRequest('Intake metadata is invalid or malformed'));
   }
@@ -173,7 +171,7 @@ const createCheckoutSession = async (
 
     if (practiceClientIntake.stripe_checkout_session_id) {
       try {
-        const resolveResult = await resolvePracticeClientIntakeByCheckoutSessionId(
+        const resolveResult = await intakeSharedHelpers.resolvePracticeClientIntakeByCheckoutSessionId(
           practiceClientIntake.stripe_checkout_session_id,
           { requireSession: true }
         );
@@ -200,7 +198,7 @@ const createCheckoutSession = async (
       }
     }
 
-    const metadata = parseMetadata(practiceClientIntake.metadata) ?? { email: '', name: '' };
+    const metadata = intakeSharedHelpers.parseMetadata(practiceClientIntake.metadata) ?? { email: '', name: '' };
 
     const session = await createIntakeCheckoutSession({
       currency: practiceClientIntake.currency,
@@ -260,7 +258,7 @@ const getIntakeStatus = async (
 
     return result.ok({
       success: true,
-      data: formatIntakeStatusResponse(intakeResult.data, {
+      data: intakeSharedHelpers.formatIntakeStatusResponse(intakeResult.data, {
         requestingUserId: ctx.userId,
         isAdmin: Boolean(ctx.memberRole),
       }),
@@ -276,7 +274,7 @@ const getIntakeStatus = async (
 
 const getPostPayStatus = async (params: { sessionId: string }): Promise<Result<IntakePostPayStatusResponse>> => {
   try {
-    const resolveResult = await resolvePracticeClientIntakeByCheckoutSessionId(params.sessionId);
+    const resolveResult = await intakeSharedHelpers.resolvePracticeClientIntakeByCheckoutSessionId(params.sessionId);
     if (!resolveResult.success) {
       return resolveResult;
     }
@@ -316,7 +314,7 @@ const claimIntake = async (
   ctx: ServiceContext
 ): Promise<Result<ClaimPracticeClientIntakeResponse>> => {
   try {
-    const resolveResult = await resolvePracticeClientIntakeByCheckoutSessionId(params.sessionId);
+    const resolveResult = await intakeSharedHelpers.resolvePracticeClientIntakeByCheckoutSessionId(params.sessionId);
     if (!resolveResult.success) {
       return resolveResult;
     }

--- a/src/modules/practice-client-intakes/services/intake-creation.service.ts
+++ b/src/modules/practice-client-intakes/services/intake-creation.service.ts
@@ -9,7 +9,7 @@ import { findPracticeDetailsByOrganization } from '@/modules/practice/database/q
 import { practiceClientIntakesRepository } from '@/modules/practice-client-intakes/database/queries/practice-client-intakes.repository';
 import type { InsertPracticeClientIntake } from '@/modules/practice-client-intakes/database/schema/practice-client-intakes.schema';
 import { getActorAccessibleIntake } from '@/modules/practice-client-intakes/services/intake-access.helpers';
-import { logger } from '@/modules/practice-client-intakes/services/intake-shared.helpers';
+import { getLogger } from '@logtape/logtape';
 import { createIntakePaymentLink } from '@/modules/practice-client-intakes/services/intake-stripe.helpers';
 import type {
   CreateIntakeResponse,
@@ -22,6 +22,8 @@ import { IntakePaymentCreated } from '@/shared/events/definitions';
 import type { Result } from '@/shared/types/result';
 import type { ServiceContext } from '@/shared/types/service-context';
 import { result } from '@/shared/utils/result';
+
+const logger = getLogger(['practice-client-intakes', 'service']);
 
 type IntakeCreationRequest = CreatePracticeClientIntakeRequest & {
   clientIp?: string;
@@ -93,7 +95,7 @@ const insertIntakeRecordTx = async (
     validatedUserId?: string;
   }
 ): Promise<Awaited<ReturnType<typeof practiceClientIntakesRepository.create>>> => {
-  let addressId: string | undefined;
+  let addressId: string | undefined = undefined;
   if (params.request.address) {
     const addressRecord = await upsertAddressTx(tx, {
       addressData: params.request.address,
@@ -195,8 +197,8 @@ const createIntake = async (params: { data: IntakeCreationRequest }): Promise<Re
       });
     }
 
-    const intake = await db.transaction(async (tx) => {
-      return insertIntakeRecordTx(tx, {
+    const intake = await db.transaction(async (tx) =>
+      insertIntakeRecordTx(tx, {
         request,
         organizationId: organization.id,
         intakeId,
@@ -204,8 +206,8 @@ const createIntake = async (params: { data: IntakeCreationRequest }): Promise<Re
         stripePaymentLinkId: stripePaymentLink?.id ?? null,
         shouldBypassPayment,
         validatedUserId,
-      });
-    });
+      })
+    );
 
     void IntakePaymentCreated.dispatch(
       {

--- a/src/modules/practice-client-intakes/services/intake-lifecycle.service.ts
+++ b/src/modules/practice-client-intakes/services/intake-lifecycle.service.ts
@@ -9,14 +9,7 @@ import {
   getStaffAccessibleIntake,
   ensureStaffOrganizationAccess,
 } from '@/modules/practice-client-intakes/services/intake-access.helpers';
-import {
-  formatIntakeListItem,
-  formatIntakeStatusResponse,
-  logger,
-  normalizeTriageStatus,
-  parseMetadata,
-  parseValidDate,
-} from '@/modules/practice-client-intakes/services/intake-shared.helpers';
+import { intakeSharedHelpers } from '@/modules/practice-client-intakes/services/intake-shared.helpers';
 import type {
   UpdateIntakeTriageStatusRequest,
   UpdateIntakeTriageStatusResponse,
@@ -31,6 +24,9 @@ import type { PaginatedResultWithMeta, Result } from '@/shared/types/result';
 import type { ServiceContext } from '@/shared/types/service-context';
 import { getMatchingFrontendUrl } from '@/shared/utils/env';
 import { result } from '@/shared/utils/result';
+import { getLogger } from '@logtape/logtape';
+
+const logger = getLogger(['practice-client-intakes', 'service']);
 
 type ListIntakeItem = NonNullable<
   z.infer<typeof intakeValidations.listIntakesResponseSchema>['data']
@@ -48,11 +44,11 @@ const listIntakes = async (
       return accessResult;
     }
 
-    if (params.query.from && !parseValidDate(params.query.from)) {
+    if (params.query.from && !intakeSharedHelpers.parseValidDate(params.query.from)) {
       return result.badRequest('Invalid date: from');
     }
 
-    if (params.query.to && !parseValidDate(params.query.to)) {
+    if (params.query.to && !intakeSharedHelpers.parseValidDate(params.query.to)) {
       return result.badRequest('Invalid date: to');
     }
 
@@ -64,7 +60,7 @@ const listIntakes = async (
     });
 
     return result.ok({
-      intakes: intakes.map((intake) => formatIntakeListItem(intake, { isAdmin: true })),
+      intakes: intakes.map((intake) => intakeSharedHelpers.formatIntakeListItem(intake, { isAdmin: true })),
       total,
       page: params.query.page,
       limit: params.query.limit,
@@ -91,7 +87,7 @@ const getIntakeById = async (
 
     return result.ok({
       success: true,
-      data: formatIntakeStatusResponse(intakeResult.data, { isAdmin: true }),
+      data: intakeSharedHelpers.formatIntakeStatusResponse(intakeResult.data, { isAdmin: true }),
     });
   } catch (error) {
     logger.error('Failed to get intake {id}: {error}', {
@@ -126,7 +122,7 @@ const updateTriageStatus = async (
       data: {
         uuid: updatedIntake.id,
         conversation_id: updatedIntake.conversation_id ?? null,
-        triage_status: normalizeTriageStatus(updatedIntake.triage_status),
+        triage_status: intakeSharedHelpers.normalizeTriageStatus(updatedIntake.triage_status),
         triage_reason: updatedIntake.triage_reason ?? null,
         triage_decided_at: updatedIntake.triage_decided_at ?? null,
       },
@@ -146,7 +142,7 @@ const createMatterFromIntakeTx = async (
     uuid: string;
     data: z.infer<typeof intakeValidations.convertIntakeSchema>;
     intake: Extract<Awaited<ReturnType<typeof getStaffAccessibleIntake>>, { success: true }>['data'];
-    metadata: NonNullable<ReturnType<typeof parseMetadata>>;
+    metadata: NonNullable<ReturnType<typeof intakeSharedHelpers.parseMetadata>>;
     userId: string;
   }
 ): Promise<string> => {
@@ -274,7 +270,7 @@ const convertIntake = async (
       return result.badRequest('Intake must be accepted before converting to a matter');
     }
 
-    const metadata = parseMetadata(intake.metadata);
+    const metadata = intakeSharedHelpers.parseMetadata(intake.metadata);
     if (!metadata) {
       return result.badRequest('Intake metadata is missing');
     }
@@ -318,7 +314,7 @@ const triggerInvitation = async (
     }
 
     const intake = intakeResult.data;
-    const metadata = parseMetadata(intake.metadata);
+    const metadata = intakeSharedHelpers.parseMetadata(intake.metadata);
     if (!metadata?.email) {
       return result.badRequest('No email address found in intake data');
     }

--- a/src/modules/practice-client-intakes/services/intake-shared.helpers.ts
+++ b/src/modules/practice-client-intakes/services/intake-shared.helpers.ts
@@ -1,5 +1,4 @@
 import { getLogger } from '@logtape/logtape';
-import type { Stripe } from 'stripe';
 import { practiceClientIntakesRepository } from '@/modules/practice-client-intakes/database/queries/practice-client-intakes.repository';
 import {
   practiceClientIntakesSchema,
@@ -10,12 +9,12 @@ import type { TriageStatus } from '@/modules/practice-client-intakes/types/pract
 import type { Result } from '@/shared/types/result';
 import { result } from '@/shared/utils/result';
 import { stripe } from '@/shared/utils/stripe-client';
+import type { ResolveCheckoutSessionResult } from '@/modules/practice-client-intakes/types/intake-stripe.types';
 
 const { practiceClientIntakeMetadataSchema } = practiceClientIntakesSchema;
+const logger = getLogger(['practice-client-intakes', 'service']);
 
-export const logger = getLogger(['practice-client-intakes', 'service']);
-
-export const normalizeTriageStatus = (value: string | null | undefined): TriageStatus => {
+const normalizeTriageStatus = (value: string | null | undefined): TriageStatus => {
   if (value === 'accepted' || value === 'declined') {
     return value;
   }
@@ -23,7 +22,7 @@ export const normalizeTriageStatus = (value: string | null | undefined): TriageS
   return 'pending_review';
 };
 
-export const parseMetadata = (rawMetadata: unknown): PracticeClientIntakeMetadata | null => {
+const parseMetadata = (rawMetadata: unknown): PracticeClientIntakeMetadata | null => {
   if (!rawMetadata) {
     return null;
   }
@@ -56,7 +55,7 @@ const isAuthorizedIntakeView = (
 const isUrgency = (value: string | null | undefined): value is 'routine' | 'time_sensitive' | 'emergency' =>
   value === 'routine' || value === 'time_sensitive' || value === 'emergency';
 
-export const formatIntakeListItem = (
+const formatIntakeListItem = (
   intake: SelectPracticeClientIntake,
   options?: { requestingUserId?: string; isAdmin?: boolean }
 ) => {
@@ -88,7 +87,7 @@ export const formatIntakeListItem = (
   };
 };
 
-export const formatIntakeStatusResponse = (
+const formatIntakeStatusResponse = (
   intake: SelectPracticeClientIntake,
   options?: { requestingUserId?: string; isAdmin?: boolean }
 ) => {
@@ -108,12 +107,7 @@ export const formatIntakeStatusResponse = (
   };
 };
 
-export interface ResolveCheckoutSessionResult {
-  intake?: Awaited<ReturnType<typeof practiceClientIntakesRepository.findById>>;
-  session?: Stripe.Checkout.Session;
-}
-
-export const resolvePracticeClientIntakeByCheckoutSessionId = async (
+const resolvePracticeClientIntakeByCheckoutSessionId = async (
   sessionId: string,
   options?: { requireSession?: boolean }
 ): Promise<Result<ResolveCheckoutSessionResult>> => {
@@ -123,6 +117,10 @@ export const resolvePracticeClientIntakeByCheckoutSessionId = async (
 
   if (intake && !requireSession) {
     return result.ok({ intake });
+  }
+
+  if (!sessionId.startsWith('cs_')) {
+    return result.notFound('Checkout session not found');
   }
 
   try {
@@ -157,7 +155,16 @@ export const resolvePracticeClientIntakeByCheckoutSessionId = async (
   }
 };
 
-export const parseValidDate = (value: string): Date | null => {
+const parseValidDate = (value: string): Date | null => {
   const date = new Date(value);
   return Number.isNaN(date.getTime()) ? null : date;
+};
+
+export const intakeSharedHelpers = {
+  normalizeTriageStatus,
+  parseMetadata,
+  resolvePracticeClientIntakeByCheckoutSessionId,
+  parseValidDate,
+  formatIntakeStatusResponse,
+  formatIntakeListItem,
 };

--- a/src/modules/practice-client-intakes/types/intake-stripe.types.ts
+++ b/src/modules/practice-client-intakes/types/intake-stripe.types.ts
@@ -1,4 +1,6 @@
 import type { PracticeClientIntakeMetadata } from '@/modules/practice-client-intakes/database/schema/practice-client-intakes.schema';
+import type { Stripe } from 'stripe';
+import type { practiceClientIntakesRepository } from '@/modules/practice-client-intakes/database/queries/practice-client-intakes.repository';
 
 export interface CreateIntakePaymentLinkParams {
   organization: {
@@ -41,4 +43,9 @@ export interface CreateIntakeCheckoutSessionParams {
     user_id?: string;
     origin?: string | null;
   };
+}
+
+export interface ResolveCheckoutSessionResult {
+  intake?: Awaited<ReturnType<typeof practiceClientIntakesRepository.findById>>;
+  session?: Stripe.Checkout.Session;
 }


### PR DESCRIPTION
- Refactor intake-shared.helpers.ts to group exports under intakeSharedHelpers.
- Move ResolveCheckoutSessionResult to intake-stripe.types.ts.
- Add fast-fail fallback in resolvePracticeClientIntakeByCheckoutSessionId to skip Stripe lookup when session_id lacks the 'cs_' prefix.
- Update lifecycle, checkout, and creation services to consume the grouped helpers and properly instantiate their own loggers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated intake helpers into a single shared helpers export and standardized local logging initialization for intake services.
* **Bug Fixes**
  * Improved checkout session validation to reject invalid session identifiers earlier and reduce error surface.
* **Types**
  * Added a new type to represent resolved checkout session results including optional session and intake data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->