### PR TITLE
Add Better Auth email templates and previews

### DIFF
--- a/src/modules/dev/http.ts
+++ b/src/modules/dev/http.ts
@@ -3,10 +3,13 @@ import path from 'node:path';
 import { type Context, Hono } from 'hono';
 import type { AppContext } from '@/shared/types/hono';
 import type {
+  ChangeEmailConfirmationData,
   CustomerPaymentReceiptData,
   CustomerPaymentRequestData,
+  EmailVerificationData,
   MagicLinkData,
   PayoutSentData,
+  PasswordResetData,
   PracticeInvitationData,
   StripeConnectStatusData,
   StripeConnectWelcomeData,
@@ -18,7 +21,10 @@ import { customerPaymentRefundRejected } from '@/shared/services/email/templates
 import { customerPaymentRefundRequest } from '@/shared/services/email/templates/customer/payment-refund-request';
 import { customerPaymentRefunded } from '@/shared/services/email/templates/customer/payment-refunded';
 import { customerPaymentRequest } from '@/shared/services/email/templates/customer/payment-request';
+import { changeEmailConfirmationTemplate } from '@/shared/services/email/templates/auth/change-email-confirmation';
+import { emailVerificationTemplate } from '@/shared/services/email/templates/auth/email-verification';
 import { magicLinkTemplate } from '@/shared/services/email/templates/auth/magic-link';
+import { passwordResetTemplate } from '@/shared/services/email/templates/auth/password-reset';
 import { payoutSent } from '@/shared/services/email/templates/onboarding/payout-sent';
 import { practiceInvitation } from '@/shared/services/email/templates/team/practice-invitation';
 import { stripeConnectStatus } from '@/shared/services/email/templates/onboarding/stripe-connect-status';
@@ -126,6 +132,22 @@ http.get('/emails/:filename', async (c) => {
 // Sample data for previews
 const sampleMagicLinkData: MagicLinkData = {
   url: 'https://blawby.com/auth/magic-link?token=sample-token-123',
+  year: 2026,
+};
+
+const samplePasswordResetData: PasswordResetData = {
+  url: 'https://blawby.com/auth/reset-password?token=sample-reset-token-123',
+  year: 2026,
+};
+
+const sampleEmailVerificationData: EmailVerificationData = {
+  url: 'https://blawby.com/api/auth/verify-email?token=sample-verify-token-123&callbackURL=https%3A%2F%2Fblawby.com%2Fsettings%2Faccount',
+  year: 2026,
+};
+
+const sampleChangeEmailConfirmationData: ChangeEmailConfirmationData = {
+  url: 'https://blawby.com/api/auth/verify-email?token=sample-change-email-token-123&callbackURL=https%3A%2F%2Fblawby.com%2Fsettings%2Faccount',
+  newEmail: 'new-email@example.com',
   year: 2026,
 };
 
@@ -418,6 +440,33 @@ http.get('/email-templates', (c) => {
       </div>
     </div>
 
+    <div class="template-card">
+      <div class="template-header">Reset your Blawby password</div>
+      <div class="template-content">
+        <div class="mobile-frame">
+          <iframe src="/api/dev/email-templates/password-reset"></iframe>
+        </div>
+      </div>
+    </div>
+
+    <div class="template-card">
+      <div class="template-header">Verify your email address</div>
+      <div class="template-content">
+        <div class="mobile-frame">
+          <iframe src="/api/dev/email-templates/email-verification"></iframe>
+        </div>
+      </div>
+    </div>
+
+    <div class="template-card">
+      <div class="template-header">Confirm your email change</div>
+      <div class="template-content">
+        <div class="mobile-frame">
+          <iframe src="/api/dev/email-templates/change-email-confirmation"></iframe>
+        </div>
+      </div>
+    </div>
+
     <div class="section-title">Customer Emails</div>
 
     <div class="template-card">
@@ -555,6 +604,33 @@ http.get('/email-templates/magic-link', (c) => {
     return devOnlyError;
   }
   const html = magicLinkTemplate(sampleMagicLinkData);
+  return c.html(html);
+});
+
+http.get('/email-templates/password-reset', (c) => {
+  const devOnlyError = guardDevelopmentOnly(c);
+  if (devOnlyError) {
+    return devOnlyError;
+  }
+  const html = passwordResetTemplate(samplePasswordResetData);
+  return c.html(html);
+});
+
+http.get('/email-templates/email-verification', (c) => {
+  const devOnlyError = guardDevelopmentOnly(c);
+  if (devOnlyError) {
+    return devOnlyError;
+  }
+  const html = emailVerificationTemplate(sampleEmailVerificationData);
+  return c.html(html);
+});
+
+http.get('/email-templates/change-email-confirmation', (c) => {
+  const devOnlyError = guardDevelopmentOnly(c);
+  if (devOnlyError) {
+    return devOnlyError;
+  }
+  const html = changeEmailConfirmationTemplate(sampleChangeEmailConfirmationData);
   return c.html(html);
 });
 

--- a/src/routes/email-preview.ts
+++ b/src/routes/email-preview.ts
@@ -3,16 +3,22 @@
  */
 
 import type {
+  ChangeEmailConfirmationData,
   CustomerPaymentReceiptData,
+  EmailVerificationData,
   MagicLinkData,
+  PasswordResetData,
   PracticeInvitationData,
   StripeConnectWelcomeData,
   WelcomeEmailData,
 } from '@/shared/services/email/email.types';
 import { Hono } from 'hono';
 import { config } from '@/shared/config';
+import { changeEmailConfirmationTemplate } from '@/shared/services/email/templates/auth/change-email-confirmation';
+import { emailVerificationTemplate } from '@/shared/services/email/templates/auth/email-verification';
 import { customerPaymentReceipt } from '@/shared/services/email/templates/customer/payment-receipt';
 import { magicLinkTemplate } from '@/shared/services/email/templates/auth/magic-link';
+import { passwordResetTemplate } from '@/shared/services/email/templates/auth/password-reset';
 import { practiceInvitation } from '@/shared/services/email/templates/team/practice-invitation';
 import { stripeConnectWelcome } from '@/shared/services/email/templates/onboarding/stripe-connect-welcome';
 import { welcomeEmail } from '@/shared/services/email/templates/onboarding/welcome';
@@ -30,6 +36,22 @@ app.use('*', async (c, next) => {
 // Sample data for previews
 const sampleMagicLinkData: MagicLinkData = {
   url: 'https://blawby.com/auth/magic-link?token=sample-token-123',
+  year: 2026,
+};
+
+const samplePasswordResetData: PasswordResetData = {
+  url: 'https://blawby.com/auth/reset-password?token=sample-reset-token-123',
+  year: 2026,
+};
+
+const sampleEmailVerificationData: EmailVerificationData = {
+  url: 'https://blawby.com/api/auth/verify-email?token=sample-verify-token-123&callbackURL=https%3A%2F%2Fblawby.com%2Fsettings%2Faccount',
+  year: 2026,
+};
+
+const sampleChangeEmailConfirmationData: ChangeEmailConfirmationData = {
+  url: 'https://blawby.com/api/auth/verify-email?token=sample-change-email-token-123&callbackURL=https%3A%2F%2Fblawby.com%2Fsettings%2Faccount',
+  newEmail: 'new-email@example.com',
   year: 2026,
 };
 
@@ -95,6 +117,21 @@ const samplePracticeInvitationData: PracticeInvitationData = {
 // Magic Link Preview
 app.get('/magic-link', (c) => {
   const html = magicLinkTemplate(sampleMagicLinkData);
+  return c.html(html);
+});
+
+app.get('/password-reset', (c) => {
+  const html = passwordResetTemplate(samplePasswordResetData);
+  return c.html(html);
+});
+
+app.get('/email-verification', (c) => {
+  const html = emailVerificationTemplate(sampleEmailVerificationData);
+  return c.html(html);
+});
+
+app.get('/change-email-confirmation', (c) => {
+  const html = changeEmailConfirmationTemplate(sampleChangeEmailConfirmationData);
   return c.html(html);
 });
 

--- a/src/shared/auth/better-auth.ts
+++ b/src/shared/auth/better-auth.ts
@@ -16,6 +16,7 @@ import { linkAnonymousUserData } from '@/shared/auth/services/link-user-data.ser
 import { getTrustedOrigins } from '@/shared/auth/utils/trustedOrigins';
 import { InvitationAccepted, PracticeMemberInvited } from '@/shared/events/definitions';
 import { queueManager } from '@/shared/queue/queue.manager';
+import { EMAIL_TEMPLATES } from '@/shared/services/email/email.types';
 import type { PrefillData } from '@/shared/types/prefill';
 import { getMatchingFrontendUrl, isDevelopment, isProductionLike } from '@/shared/utils/env';
 import { sanitizeError } from '@/shared/utils/logging';
@@ -194,8 +195,35 @@ const betterAuthConfig = (db: NodePgDatabase<typeof schema>, googleRedirectUri?:
         },
       },
     },
-    emailAndPassword: AUTH_CONFIG.emailAndPassword,
+    emailVerification: {
+      sendVerificationEmail: async ({ user, url }) => {
+        await queueManager.addEmailJob(
+          EMAIL_TEMPLATES.EMAIL_VERIFICATION,
+          user.email,
+          'Verify your email address',
+          {
+            url,
+            year: new Date().getFullYear(),
+          }
+        );
+      },
+    },
     user: {
+      changeEmail: {
+        enabled: true,
+        sendChangeEmailConfirmation: async ({ user, newEmail, url }) => {
+          await queueManager.addEmailJob(
+            EMAIL_TEMPLATES.CHANGE_EMAIL_CONFIRMATION,
+            user.email,
+            'Confirm your email change',
+            {
+              newEmail,
+              url,
+              year: new Date().getFullYear(),
+            }
+          );
+        },
+      },
       additionalFields: {
         primaryWorkspace: {
           type: ['public', 'client', 'practice'],
@@ -222,6 +250,20 @@ const betterAuthConfig = (db: NodePgDatabase<typeof schema>, googleRedirectUri?:
           required: false,
           defaultValue: false,
         },
+      },
+    },
+    emailAndPassword: {
+      ...AUTH_CONFIG.emailAndPassword,
+      sendResetPassword: async ({ user, url }) => {
+        await queueManager.addEmailJob(
+          EMAIL_TEMPLATES.PASSWORD_RESET,
+          user.email,
+          'Reset your Blawby password',
+          {
+            url,
+            year: new Date().getFullYear(),
+          }
+        );
       },
     },
     socialProviders: {

--- a/src/shared/auth/better-auth.ts
+++ b/src/shared/auth/better-auth.ts
@@ -197,15 +197,10 @@ const betterAuthConfig = (db: NodePgDatabase<typeof schema>, googleRedirectUri?:
     },
     emailVerification: {
       sendVerificationEmail: async ({ user, url }) => {
-        await queueManager.addEmailJob(
-          EMAIL_TEMPLATES.EMAIL_VERIFICATION,
-          user.email,
-          'Verify your email address',
-          {
-            url,
-            year: new Date().getFullYear(),
-          }
-        );
+        await queueManager.addEmailJob(EMAIL_TEMPLATES.EMAIL_VERIFICATION, user.email, 'Verify your email address', {
+          url,
+          year: new Date().getFullYear(),
+        });
       },
     },
     user: {
@@ -226,7 +221,7 @@ const betterAuthConfig = (db: NodePgDatabase<typeof schema>, googleRedirectUri?:
       },
       deleteUser: {
         enabled: true,
-      }
+      },
       additionalFields: {
         primaryWorkspace: {
           type: ['public', 'client', 'practice'],
@@ -258,15 +253,10 @@ const betterAuthConfig = (db: NodePgDatabase<typeof schema>, googleRedirectUri?:
     emailAndPassword: {
       ...AUTH_CONFIG.emailAndPassword,
       sendResetPassword: async ({ user, url }) => {
-        await queueManager.addEmailJob(
-          EMAIL_TEMPLATES.PASSWORD_RESET,
-          user.email,
-          'Reset your Blawby password',
-          {
-            url,
-            year: new Date().getFullYear(),
-          }
-        );
+        await queueManager.addEmailJob(EMAIL_TEMPLATES.PASSWORD_RESET, user.email, 'Reset your Blawby password', {
+          url,
+          year: new Date().getFullYear(),
+        });
       },
     },
     socialProviders: {

--- a/src/shared/services/email/email.types.ts
+++ b/src/shared/services/email/email.types.ts
@@ -28,6 +28,9 @@ export const EMAIL_TEMPLATES = {
   SCHEDULED_EVENT: 'scheduled-event',
   // Auth
   MAGIC_LINK: 'magic-link',
+  PASSWORD_RESET: 'password-reset',
+  EMAIL_VERIFICATION: 'email-verification',
+  CHANGE_EMAIL_CONFIRMATION: 'change-email-confirmation',
   // Intakes
   INTAKE_SUBMISSION_RECEIVED: 'intake-submission-received',
   INTAKE_NEW_NOTIFICATION: 'intake-new-notification',
@@ -55,6 +58,22 @@ export interface ScheduledEventData {
  */
 export interface MagicLinkData {
   url: string;
+  year: number;
+}
+
+export interface PasswordResetData {
+  url: string;
+  year: number;
+}
+
+export interface EmailVerificationData {
+  url: string;
+  year: number;
+}
+
+export interface ChangeEmailConfirmationData {
+  url: string;
+  newEmail: string;
   year: number;
 }
 

--- a/src/shared/services/email/templates/auth/change-email-confirmation.ts
+++ b/src/shared/services/email/templates/auth/change-email-confirmation.ts
@@ -1,0 +1,108 @@
+import { type ChangeEmailConfirmationData } from '@/shared/services/email/email.types';
+
+export const changeEmailConfirmationTemplate = (data: ChangeEmailConfirmationData): string => `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Confirm your email change</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      line-height: 1.6;
+      color: #1a1a1a;
+      margin: 0;
+      padding: 0;
+      background-color: #f9fafb;
+    }
+    .wrapper {
+      padding: 40px 20px;
+    }
+    .container {
+      max-width: 600px;
+      margin: 0 auto;
+      background: #ffffff;
+      border-radius: 12px;
+      overflow: hidden;
+      box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    }
+    .header {
+      padding: 32px 40px 0;
+      text-align: center;
+    }
+    .content {
+      padding: 32px 40px;
+    }
+    .footer {
+      padding: 24px 40px;
+      background: #f8fafc;
+      text-align: center;
+      font-size: 14px;
+      color: #64748b;
+    }
+    .button {
+      display: inline-block;
+      padding: 14px 32px;
+      background-color: #1a202c;
+      color: #ffffff !important;
+      text-decoration: none;
+      border-radius: 8px;
+      font-weight: 600;
+      margin: 24px 0;
+    }
+    h1 {
+      font-size: 24px;
+      font-weight: 700;
+      color: #1e293b;
+      margin: 0 0 16px;
+    }
+    p {
+      margin: 0 0 16px;
+    }
+    .link-alt {
+      font-size: 12px;
+      color: #94a3b8;
+      word-break: break-all;
+    }
+    .email-pill {
+      display: inline-block;
+      padding: 6px 12px;
+      border-radius: 9999px;
+      background: #f1f5f9;
+      color: #0f172a;
+      font-size: 14px;
+      font-weight: 600;
+      margin-bottom: 8px;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+    <div class="container">
+      <div class="header">
+        <img src="https://imagedelivery.net/Frxyb2_d_vGyiaXhS5xqCg/27bc2bf2-8582-4ed1-e77c-45d7a3215b00/public" alt="Blawby" width="120" style="margin-bottom: 24px;">
+      </div>
+      <div class="content">
+        <h1>Confirm your email change</h1>
+        <p>You requested to change the email on your Blawby account to:</p>
+        <div class="email-pill">${data.newEmail}</div>
+        <p>Click below to confirm this change.</p>
+
+        <div style="text-align: center;">
+          <a href="${data.url}" class="button">Confirm Email Change</a>
+        </div>
+
+        <p>If the button doesn't work, copy and paste this link into your browser:</p>
+        <p class="link-alt">${data.url}</p>
+
+        <p>If you didn't request this change, you can safely ignore this email.</p>
+      </div>
+      <div class="footer">
+        &copy; ${data.year} Blawby. All rights reserved.
+      </div>
+    </div>
+  </div>
+</body>
+</html>
+`;

--- a/src/shared/services/email/templates/auth/email-verification.ts
+++ b/src/shared/services/email/templates/auth/email-verification.ts
@@ -1,0 +1,94 @@
+import { type EmailVerificationData } from '@/shared/services/email/email.types';
+
+export const emailVerificationTemplate = (data: EmailVerificationData): string => `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Verify your email address</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      line-height: 1.6;
+      color: #1a1a1a;
+      margin: 0;
+      padding: 0;
+      background-color: #f9fafb;
+    }
+    .wrapper {
+      padding: 40px 20px;
+    }
+    .container {
+      max-width: 600px;
+      margin: 0 auto;
+      background: #ffffff;
+      border-radius: 12px;
+      overflow: hidden;
+      box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    }
+    .header {
+      padding: 32px 40px 0;
+      text-align: center;
+    }
+    .content {
+      padding: 32px 40px;
+    }
+    .footer {
+      padding: 24px 40px;
+      background: #f8fafc;
+      text-align: center;
+      font-size: 14px;
+      color: #64748b;
+    }
+    .button {
+      display: inline-block;
+      padding: 14px 32px;
+      background-color: #1a202c;
+      color: #ffffff !important;
+      text-decoration: none;
+      border-radius: 8px;
+      font-weight: 600;
+      margin: 24px 0;
+    }
+    h1 {
+      font-size: 24px;
+      font-weight: 700;
+      color: #1e293b;
+      margin: 0 0 16px;
+    }
+    p {
+      margin: 0 0 16px;
+    }
+    .link-alt {
+      font-size: 12px;
+      color: #94a3b8;
+      word-break: break-all;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+    <div class="container">
+      <div class="header">
+        <img src="https://imagedelivery.net/Frxyb2_d_vGyiaXhS5xqCg/27bc2bf2-8582-4ed1-e77c-45d7a3215b00/public" alt="Blawby" width="120" style="margin-bottom: 24px;">
+      </div>
+      <div class="content">
+        <h1>Verify your email</h1>
+        <p>Click the button below to verify this email address for your Blawby account.</p>
+
+        <div style="text-align: center;">
+          <a href="${data.url}" class="button">Verify Email</a>
+        </div>
+
+        <p>If the button doesn't work, copy and paste this link into your browser:</p>
+        <p class="link-alt">${data.url}</p>
+      </div>
+      <div class="footer">
+        &copy; ${data.year} Blawby. All rights reserved.
+      </div>
+    </div>
+  </div>
+</body>
+</html>
+`;

--- a/src/shared/services/email/templates/auth/password-reset.ts
+++ b/src/shared/services/email/templates/auth/password-reset.ts
@@ -1,0 +1,96 @@
+import { type PasswordResetData } from '@/shared/services/email/email.types';
+
+export const passwordResetTemplate = (data: PasswordResetData): string => `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reset your Blawby password</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      line-height: 1.6;
+      color: #1a1a1a;
+      margin: 0;
+      padding: 0;
+      background-color: #f9fafb;
+    }
+    .wrapper {
+      padding: 40px 20px;
+    }
+    .container {
+      max-width: 600px;
+      margin: 0 auto;
+      background: #ffffff;
+      border-radius: 12px;
+      overflow: hidden;
+      box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    }
+    .header {
+      padding: 32px 40px 0;
+      text-align: center;
+    }
+    .content {
+      padding: 32px 40px;
+    }
+    .footer {
+      padding: 24px 40px;
+      background: #f8fafc;
+      text-align: center;
+      font-size: 14px;
+      color: #64748b;
+    }
+    .button {
+      display: inline-block;
+      padding: 14px 32px;
+      background-color: #1a202c;
+      color: #ffffff !important;
+      text-decoration: none;
+      border-radius: 8px;
+      font-weight: 600;
+      margin: 24px 0;
+    }
+    h1 {
+      font-size: 24px;
+      font-weight: 700;
+      color: #1e293b;
+      margin: 0 0 16px;
+    }
+    p {
+      margin: 0 0 16px;
+    }
+    .link-alt {
+      font-size: 12px;
+      color: #94a3b8;
+      word-break: break-all;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+    <div class="container">
+      <div class="header">
+        <img src="https://imagedelivery.net/Frxyb2_d_vGyiaXhS5xqCg/27bc2bf2-8582-4ed1-e77c-45d7a3215b00/public" alt="Blawby" width="120" style="margin-bottom: 24px;">
+      </div>
+      <div class="content">
+        <h1>Reset your password</h1>
+        <p>Click the button below to choose a new password for your Blawby account.</p>
+
+        <div style="text-align: center;">
+          <a href="${data.url}" class="button">Reset Password</a>
+        </div>
+
+        <p>If the button doesn't work, copy and paste this link into your browser:</p>
+        <p class="link-alt">${data.url}</p>
+
+        <p>If you didn't request this change, you can safely ignore this email.</p>
+      </div>
+      <div class="footer">
+        &copy; ${data.year} Blawby. All rights reserved.
+      </div>
+    </div>
+  </div>
+</body>
+</html>
+`;

--- a/src/shared/services/email/templates/index.ts
+++ b/src/shared/services/email/templates/index.ts
@@ -16,6 +16,9 @@ import {
   type PayoutSentData,
   type ScheduledEventData,
   type MagicLinkData,
+  type PasswordResetData,
+  type EmailVerificationData,
+  type ChangeEmailConfirmationData,
   type PracticeInvitationData,
   type IntakeSubmissionReceivedData,
   type IntakeNewNotificationData,
@@ -27,6 +30,9 @@ import {
 
 // Auth templates
 import { magicLinkTemplate } from '@/shared/services/email/templates/auth/magic-link';
+import { passwordResetTemplate } from '@/shared/services/email/templates/auth/password-reset';
+import { emailVerificationTemplate } from '@/shared/services/email/templates/auth/email-verification';
+import { changeEmailConfirmationTemplate } from '@/shared/services/email/templates/auth/change-email-confirmation';
 
 // Customer templates
 import { customerPaymentReceipt } from '@/shared/services/email/templates/customer/payment-receipt';
@@ -81,6 +87,9 @@ export interface TemplateDataMap {
   [EMAIL_TEMPLATES.PAYOUT_SENT]: PayoutSentData;
   [EMAIL_TEMPLATES.SCHEDULED_EVENT]: ScheduledEventData;
   [EMAIL_TEMPLATES.MAGIC_LINK]: MagicLinkData;
+  [EMAIL_TEMPLATES.PASSWORD_RESET]: PasswordResetData;
+  [EMAIL_TEMPLATES.EMAIL_VERIFICATION]: EmailVerificationData;
+  [EMAIL_TEMPLATES.CHANGE_EMAIL_CONFIRMATION]: ChangeEmailConfirmationData;
   [EMAIL_TEMPLATES.INTAKE_SUBMISSION_RECEIVED]: IntakeSubmissionReceivedData;
   [EMAIL_TEMPLATES.INTAKE_NEW_NOTIFICATION]: IntakeNewNotificationData;
   [EMAIL_TEMPLATES.INTAKE_ACCEPTED]: IntakeAcceptedData;
@@ -115,6 +124,9 @@ const templateRegistry = {
   [EMAIL_TEMPLATES.PAYOUT_SENT]: payoutSent,
   [EMAIL_TEMPLATES.SCHEDULED_EVENT]: scheduledEventTemplate,
   [EMAIL_TEMPLATES.MAGIC_LINK]: magicLinkTemplate,
+  [EMAIL_TEMPLATES.PASSWORD_RESET]: passwordResetTemplate,
+  [EMAIL_TEMPLATES.EMAIL_VERIFICATION]: emailVerificationTemplate,
+  [EMAIL_TEMPLATES.CHANGE_EMAIL_CONFIRMATION]: changeEmailConfirmationTemplate,
 
   // Intake templates
   [EMAIL_TEMPLATES.INTAKE_SUBMISSION_RECEIVED]: intakeSubmissionReceived,
@@ -152,6 +164,9 @@ export {
   payoutSent,
   scheduledEventTemplate,
   magicLinkTemplate,
+  passwordResetTemplate,
+  emailVerificationTemplate,
+  changeEmailConfirmationTemplate,
   intakeSubmissionReceived,
   intakeNewNotification,
   intakeAccepted,


### PR DESCRIPTION
## Summary
- add Better Auth email verification, change-email confirmation, and password reset email hooks
- register the new auth email templates and sample data
- expose the new auth templates in the backend preview routes and dev email gallery

## Validation
- pnpm lint (blocked: repo-level oxlint config parse error unrelated to this diff)
- pnpm typecheck (blocked: existing repo-wide schema/router/type errors unrelated to this diff)

## Notes
- backend validation could not be completed cleanly because the current branch already has unrelated failures outside these files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three authentication email templates: password reset, email verification, and email change confirmation.
  * Authentication flows now send these templated emails where applicable.
  * Development preview pages added to view and test each email template in the dev environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->