### PR TITLE
feat: implement matter tasks CRUD with activity logging

### DIFF
--- a/src/modules/matters/handlers.ts
+++ b/src/modules/matters/handlers.ts
@@ -3,6 +3,7 @@ import { matterActivityService } from '@/modules/matters/services/matter-activit
 import { matterExpensesService } from '@/modules/matters/services/matter-expenses.service';
 import { matterMilestonesService } from '@/modules/matters/services/matter-milestones.service';
 import { matterNotesService } from '@/modules/matters/services/matter-notes.service';
+import { matterTasksService } from '@/modules/matters/services/matter-tasks.service';
 import { matterTimeEntriesService } from '@/modules/matters/services/matter-time-entries.service';
 import { mattersService } from '@/modules/matters/services/matters.service';
 import type { AppRouteHandler } from '@/shared/types/hono';
@@ -290,8 +291,62 @@ const reorderMilestonesHandler: AppRouteHandler<typeof matterRoutes.reorderMiles
   return sendResult(c, result);
 };
 
-const listMatterTasksHandler: AppRouteHandler<typeof matterRoutes.listMatterTasksRoute> = async (c) =>
-  c.json({ error: 'Matter tasks are not yet implemented' }, 501);
+const listMatterTasksHandler: AppRouteHandler<typeof matterRoutes.listMatterTasksRoute> = async (c) => {
+  const ctx = getServiceContext(c);
+  const { id: matterId } = c.req.valid('param');
+  const query = c.req.valid('query');
+
+  const result = await matterTasksService.listMatterTasks(
+    { matterId, filters: query },
+    ctx
+  );
+
+  if (!result.success) {
+    return sendResult(c, result);
+  }
+  return c.json({ tasks: result.data }, 200);
+};
+
+const createMatterTaskHandler: AppRouteHandler<typeof matterRoutes.createMatterTaskRoute> = async (c) => {
+  const ctx = getServiceContext(c);
+  const { id: matterId } = c.req.valid('param');
+  const validatedBody = c.req.valid('json');
+
+  const result = await matterTasksService.createMatterTask(
+    { matterId, data: validatedBody },
+    ctx
+  );
+
+  return sendResult(c, result, 201);
+};
+
+const updateMatterTaskHandler: AppRouteHandler<typeof matterRoutes.updateMatterTaskRoute> = async (c) => {
+  const ctx = getServiceContext(c);
+  const { id: matterId, task_id: taskId } = c.req.valid('param');
+  const validatedBody = c.req.valid('json');
+
+  const result = await matterTasksService.updateMatterTask(
+    { matterId, taskId, data: validatedBody },
+    ctx
+  );
+
+  return sendResult(c, result);
+};
+
+const deleteMatterTaskHandler: AppRouteHandler<typeof matterRoutes.deleteMatterTaskRoute> = async (c) => {
+  const ctx = getServiceContext(c);
+  const { id: matterId, task_id: taskId } = c.req.valid('param');
+
+  const result = await matterTasksService.deleteMatterTask(
+    { matterId, taskId },
+    ctx
+  );
+
+  if (!result.success) {
+    return sendResult(c, result);
+  }
+  return c.json({ success: true }, 200);
+};
 const getMatterUnbilledHandler: AppRouteHandler<typeof matterRoutes.getMatterUnbilledRoute> = async (c) => {
   const ctx = getServiceContext(c);
   const { id: matterId } = c.req.valid('param');
@@ -328,5 +383,8 @@ export const handlers = {
   updateMatterNoteHandler,
   deleteMatterNoteHandler,
   listMatterTasksHandler,
+  createMatterTaskHandler,
+  updateMatterTaskHandler,
+  deleteMatterTaskHandler,
   getMatterUnbilledHandler,
 };

--- a/src/modules/matters/routes/index.ts
+++ b/src/modules/matters/routes/index.ts
@@ -25,7 +25,12 @@ import {
   updateMatterNoteRoute,
   deleteMatterNoteRoute,
 } from '@/modules/matters/routes/notes.routes';
-import { listMatterTasksRoute } from '@/modules/matters/routes/tasks.routes';
+import { 
+  listMatterTasksRoute, 
+  createMatterTaskRoute, 
+  updateMatterTaskRoute, 
+  deleteMatterTaskRoute 
+} from '@/modules/matters/routes/tasks.routes';
 import {
   listTimeEntriesRoute,
   createTimeEntryRoute,
@@ -62,5 +67,8 @@ export const routes = {
   deleteMilestoneRoute,
   reorderMilestonesRoute,
   listMatterTasksRoute,
+  createMatterTaskRoute,
+  updateMatterTaskRoute,
+  deleteMatterTaskRoute,
   getMatterUnbilledRoute,
 };

--- a/src/modules/matters/routes/tasks.routes.ts
+++ b/src/modules/matters/routes/tasks.routes.ts
@@ -1,4 +1,10 @@
 import { z } from '@hono/zod-openapi';
+import {
+  createMatterTaskRequestSchema,
+  updateMatterTaskRequestSchema,
+  matterTaskResponseSchema,
+  listMatterTasksQuerySchema,
+} from '@/modules/matters/types/matter.types';
 import { routeBuilder } from '@/shared/router/route-builder';
 
 const tags = ['Matters'];
@@ -7,13 +13,18 @@ const matterIdParamSchema = z.object({
   id: z.uuid(),
 });
 
+const taskIdParamSchema = z.object({
+  task_id: z.uuid(),
+});
+
 export const listMatterTasksRoute = routeBuilder.build({
   method: 'get',
   path: '/{id}/tasks',
   tags,
-  summary: 'List matter tasks (not implemented)',
+  summary: 'List matter tasks',
   request: {
     params: matterIdParamSchema,
+    query: listMatterTasksQuerySchema,
   },
   responses: {
     200: {
@@ -21,25 +32,83 @@ export const listMatterTasksRoute = routeBuilder.build({
       content: {
         'application/json': {
           schema: z.object({
-            tasks: z.array(
-              z.object({
-                id: z.uuid(),
-                title: z.string(),
-                status: z.string(),
-                due_date: z.string().nullable().optional(),
-                assigned_to: z.uuid().nullable().optional(),
-              })
-            ),
+            tasks: z.array(matterTaskResponseSchema),
           }),
         },
       },
     },
-    501: {
-      description: 'Matter tasks are not yet implemented',
+  },
+});
+
+export const createMatterTaskRoute = routeBuilder.build({
+  method: 'post',
+  path: '/{id}/tasks',
+  tags,
+  summary: 'Create a matter task',
+  request: {
+    params: matterIdParamSchema,
+    body: {
+      content: {
+        'application/json': {
+          schema: createMatterTaskRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      description: 'Task created successfully',
+      content: {
+        'application/json': {
+          schema: matterTaskResponseSchema,
+        },
+      },
+    },
+  },
+});
+
+export const updateMatterTaskRoute = routeBuilder.build({
+  method: 'put',
+  path: '/{id}/tasks/{task_id}',
+  tags,
+  summary: 'Update a matter task',
+  request: {
+    params: matterIdParamSchema.merge(taskIdParamSchema),
+    body: {
+      content: {
+        'application/json': {
+          schema: updateMatterTaskRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: 'Task updated successfully',
+      content: {
+        'application/json': {
+          schema: matterTaskResponseSchema,
+        },
+      },
+    },
+  },
+});
+
+export const deleteMatterTaskRoute = routeBuilder.build({
+  method: 'delete',
+  path: '/{id}/tasks/{task_id}',
+  tags,
+  summary: 'Delete a matter task',
+  request: {
+    params: matterIdParamSchema.merge(taskIdParamSchema),
+  },
+  responses: {
+    200: {
+      description: 'Task deleted successfully',
       content: {
         'application/json': {
           schema: z.object({
-            error: z.string(),
+            success: z.boolean(),
           }),
         },
       },

--- a/src/modules/matters/services/matter-tasks.service.ts
+++ b/src/modules/matters/services/matter-tasks.service.ts
@@ -1,0 +1,249 @@
+import { getLogger } from '@logtape/logtape';
+import { matterTasksQueries } from '@/modules/matters/database/queries/matter-tasks.queries';
+import type { SelectMatterTask } from '@/modules/matters/database/schema/matter-tasks.schema';
+import { matterActivityService } from '@/modules/matters/services/matter-activity.service';
+import { mattersService } from '@/modules/matters/services/matters.service';
+import type { MatterTaskListFilters } from '@/modules/matters/types/matter-filters.types';
+import type { CreateMatterTaskRequest, UpdateMatterTaskRequest } from '@/modules/matters/types/matter.types';
+import type { Result } from '@/shared/types/result';
+import type { ServiceContext } from '@/shared/types/service-context';
+import { ok, notFound, internalError } from '@/shared/utils/result';
+
+const logger = getLogger(['matters', 'services', 'tasks']);
+
+const createMatterTask = async (
+  params: { matterId: string; data: CreateMatterTaskRequest },
+  ctx: ServiceContext
+): Promise<Result<SelectMatterTask>> => {
+  try {
+    // Verify matter exists and user has access
+    const matterResult = await mattersService.getMatterById(params.matterId, ctx);
+    if (!matterResult.success) {
+      return matterResult as Result<never>;
+    }
+
+    const taskData = {
+      ...params.data,
+      matter_id: params.matterId,
+    };
+
+    const [task] = await matterTasksQueries.createMatterTasks(taskData);
+
+    // Log activity
+    const userName = ctx.user?.name || ctx.user?.email || 'Unknown User';
+    const assigneeInfo = params.data.assignee_id 
+      ? ` (assigned to user)` 
+      : '';
+    const priorityInfo = params.data.priority !== 'normal' 
+      ? ` (${params.data.priority} priority)` 
+      : '';
+    
+    const activityResult = await matterActivityService.logMatterActivity(
+      {
+        action: matterActivityService.ActivityAction.TASK_CREATED,
+        description: `${userName} created task: ${params.data.name}${assigneeInfo}${priorityInfo}`,
+        metadata: { 
+          task_id: task.id,
+          assignee_id: params.data.assignee_id,
+          priority: params.data.priority,
+          stage: params.data.stage,
+          changed_fields: ['created'] 
+        },
+      },
+      ctx
+    );
+
+    if (!activityResult.success) {
+      logger.error('Failed to log task create activity {matterId}: {error}', {
+        matterId: params.matterId,
+        error: activityResult.error.message,
+      });
+    }
+
+    return ok(task);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    logger.error('Failed to create matter task {matterId}: {error}', {
+      matterId: params.matterId,
+      error: message,
+    });
+    return internalError('Failed to create matter task');
+  }
+};
+
+const listMatterTasks = async (
+  params: { matterId: string; filters?: MatterTaskListFilters },
+  ctx: ServiceContext
+): Promise<Result<SelectMatterTask[]>> => {
+  try {
+    // Verify matter exists and user has access
+    const matterResult = await mattersService.getMatterById(params.matterId, ctx);
+    if (!matterResult.success) {
+      return matterResult as Result<never>;
+    }
+
+    const tasks = await matterTasksQueries.listMatterTasks(params.matterId, params.filters);
+    return ok(tasks);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    logger.error('Failed to list matter tasks {matterId}: {error}', {
+      matterId: params.matterId,
+      error: message,
+    });
+    return internalError('Failed to list matter tasks');
+  }
+};
+
+const updateMatterTask = async (
+  params: { matterId: string; taskId: string; data: UpdateMatterTaskRequest },
+  ctx: ServiceContext
+): Promise<Result<SelectMatterTask>> => {
+  try {
+    // Verify matter exists and user has access
+    const matterResult = await mattersService.getMatterById(params.matterId, ctx);
+    if (!matterResult.success) {
+      return matterResult as Result<never>;
+    }
+
+    // Get existing task to track changes
+    const existingTask = await matterTasksQueries.findMatterTaskById(params.taskId);
+    if (!existingTask || existingTask.matter_id !== params.matterId) {
+      return notFound('Task not found');
+    }
+
+    const updatedTask = await matterTasksQueries.updateMatterTask(params.taskId, params.data);
+    if (!updatedTask) {
+      return notFound('Task not found');
+    }
+
+    // Track changed fields for activity logging
+    const changedFields: string[] = [];
+    if (params.data.name !== undefined && params.data.name !== existingTask.name) {
+      changedFields.push('name');
+    }
+    if (params.data.description !== undefined && params.data.description !== existingTask.description) {
+      changedFields.push('description');
+    }
+    if (params.data.assignee_id !== undefined && params.data.assignee_id !== existingTask.assignee_id) {
+      changedFields.push('assignee_id');
+    }
+    if (params.data.due_date !== undefined && params.data.due_date !== existingTask.due_date) {
+      changedFields.push('due_date');
+    }
+    if (params.data.status !== undefined && params.data.status !== existingTask.status) {
+      changedFields.push('status');
+    }
+    if (params.data.priority !== undefined && params.data.priority !== existingTask.priority) {
+      changedFields.push('priority');
+    }
+    if (params.data.stage !== undefined && params.data.stage !== existingTask.stage) {
+      changedFields.push('stage');
+    }
+
+    // Log activity
+    if (changedFields.length > 0) {
+      const userName = ctx.user?.name || ctx.user?.email || 'Unknown User';
+      let description = `${userName} updated task: ${updatedTask.name}`;
+      
+      // Add specific status change info
+      if (params.data.status && params.data.status !== existingTask.status) {
+        if (params.data.status === 'complete') {
+          description = `${userName} completed task: ${updatedTask.name}`;
+        } else {
+          description = `${userName} changed task status to ${params.data.status}: ${updatedTask.name}`;
+        }
+      }
+
+      const activityResult = await matterActivityService.logMatterActivity(
+        {
+          action: params.data.status === 'complete' 
+            ? matterActivityService.ActivityAction.TASK_COMPLETED
+            : matterActivityService.ActivityAction.TASK_UPDATED,
+          description,
+          metadata: { 
+            task_id: updatedTask.id,
+            changed_fields: changedFields,
+            old_status: existingTask.status,
+            new_status: updatedTask.status,
+          },
+        },
+        ctx
+      );
+
+      if (!activityResult.success) {
+        logger.error('Failed to log task update activity {taskId}: {error}', {
+          taskId: params.taskId,
+          error: activityResult.error.message,
+        });
+      }
+    }
+
+    return ok(updatedTask);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    logger.error('Failed to update matter task {taskId}: {error}', {
+      taskId: params.taskId,
+      error: message,
+    });
+    return internalError('Failed to update matter task');
+  }
+};
+
+const deleteMatterTask = async (
+  params: { matterId: string; taskId: string },
+  ctx: ServiceContext
+): Promise<Result<void>> => {
+  try {
+    // Verify matter exists and user has access
+    const matterResult = await mattersService.getMatterById(params.matterId, ctx);
+    if (!matterResult.success) {
+      return matterResult as Result<never>;
+    }
+
+    // Get task details for activity logging before deletion
+    const existingTask = await matterTasksQueries.findMatterTaskById(params.taskId);
+    if (!existingTask || existingTask.matter_id !== params.matterId) {
+      return notFound('Task not found');
+    }
+
+    await matterTasksQueries.deleteMatterTask(params.taskId);
+
+    // Log activity
+    const userName = ctx.user?.name || ctx.user?.email || 'Unknown User';
+    const activityResult = await matterActivityService.logMatterActivity(
+      {
+        action: matterActivityService.ActivityAction.TASK_DELETED,
+        description: `${userName} deleted task: ${existingTask.name}`,
+        metadata: { 
+          task_id: params.taskId,
+          task_name: existingTask.name,
+          changed_fields: ['deleted'] 
+        },
+      },
+      ctx
+    );
+
+    if (!activityResult.success) {
+      logger.error('Failed to log task delete activity {taskId}: {error}', {
+        taskId: params.taskId,
+        error: activityResult.error.message,
+      });
+    }
+
+    return ok(undefined);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    logger.error('Failed to delete matter task {taskId}: {error}', {
+      taskId: params.taskId,
+      error: message,
+    });
+    return internalError('Failed to delete matter task');
+  }
+};
+
+export const matterTasksService = {
+  createMatterTask,
+  listMatterTasks,
+  updateMatterTask,
+  deleteMatterTask,
+};

--- a/src/modules/matters/types/matter.types.ts
+++ b/src/modules/matters/types/matter.types.ts
@@ -7,7 +7,7 @@ import type { SelectMatter } from '@/modules/matters/database/schema/matters.sch
 import { matterExpenseValidations } from '@/modules/matters/validations/matter-expenses.validation';
 import { matterMilestoneValidations } from '@/modules/matters/validations/matter-milestones.validation';
 import { matterNoteValidations } from '@/modules/matters/validations/matter-notes.validation';
-import type { matterTaskValidations } from '@/modules/matters/validations/matter-tasks.validation';
+import { matterTaskValidations } from '@/modules/matters/validations/matter-tasks.validation';
 import { matterTimeEntryValidations } from '@/modules/matters/validations/matter-time-entries.validation';
 import { matterValidations } from '@/modules/matters/validations/matters.validation';
 // Export schemas
@@ -39,6 +39,11 @@ export const createMatterTimeEntryRequestSchema = matterTimeEntryValidations.cre
 export const updateMatterTimeEntryRequestSchema = matterTimeEntryValidations.updateMatterTimeEntrySchema;
 export const matterTimeEntryResponseSchema = matterTimeEntryValidations.timeEntrySchema;
 export const listMatterTimeEntriesQuerySchema = matterTimeEntryValidations.listTimeEntriesQuerySchema;
+
+export const createMatterTaskRequestSchema = matterTaskValidations.createMatterTaskSchema;
+export const updateMatterTaskRequestSchema = matterTaskValidations.updateMatterTaskSchema;
+export const matterTaskResponseSchema = matterTaskValidations.matterTaskSchema;
+export const listMatterTasksQuerySchema = matterTaskValidations.listMatterTasksQuerySchema;
 
 /**
  * Matter with relations

--- a/src/shared/auth/better-auth.ts
+++ b/src/shared/auth/better-auth.ts
@@ -1,7 +1,7 @@
 import { getLogger } from '@logtape/logtape';
 import { betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
-import { admin, anonymous, magicLink, organization, testUtils } from 'better-auth/plugins';
+import { admin, anonymous, magicLink, organization } from 'better-auth/plugins';
 import { eq } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 // Schema is used as namespace for drizzle adapter
@@ -135,7 +135,6 @@ const betterAuthConfig = (db: NodePgDatabase<typeof schema>, googleRedirectUri?:
           });
         },
       }),
-      ...(isDevelopment() ? [testUtils()] : []),
     ],
     baseURL: config.app.baseUrl || undefined,
     basePath: '/api/auth',

--- a/src/shared/utils/stripe-client.ts
+++ b/src/shared/utils/stripe-client.ts
@@ -21,7 +21,7 @@ const initStripe = (): Stripe => {
     }
 
     _stripeInstance = new Stripe(apiKey, {
-      apiVersion: '2026-02-25.clover',
+      apiVersion: '2025-12-15.clover',
     });
   }
 


### PR DESCRIPTION
- Add matter-tasks.service.ts with full CRUD operations
- Add task routes (create, update, delete, list)
- Implement task handlers with proper error handling
- Add task schema exports to matter.types.ts
- Fix build issues: remove testUtils import, update Stripe API version
- Tasks are assignable with status tracking and activity timeline integration