### PR TITLE
feat(intake): validate consultation fee matches practice fee in intake creation

### DIFF
--- a/src/modules/practice-client-intakes/services/intake-creation.service.ts
+++ b/src/modules/practice-client-intakes/services/intake-creation.service.ts
@@ -154,6 +154,11 @@ const createIntake = async (params: { data: IntakeCreationRequest }): Promise<Re
 
     const practiceDetails = await findPracticeDetailsByOrganization(organization.id);
     const consultationFee = practiceDetails?.consultation_fee ?? 0;
+
+    if (request.amount !== consultationFee) {
+      return result.badRequest('Amount must match the practice consultation fee');
+    }
+
     const requiresPayment = Boolean(organization.paymentLinkEnabled) && consultationFee > 0;
     const shouldBypassPayment = !requiresPayment || request.amount === 0;
 

--- a/src/modules/practice-client-intakes/validations/practice-client-intakes.validation.ts
+++ b/src/modules/practice-client-intakes/validations/practice-client-intakes.validation.ts
@@ -5,7 +5,11 @@ import { addressSchema } from '@/shared/validations/address';
 // Public request schema - clientIp and userAgent are injected server-side from headers
 const createPracticeClientIntakeSchema = z.object({
   slug: z.string().min(1).max(100),
-  amount: z.number().int().min(0).max(99999999), // $0.00 to $999,999.99
+  amount: z.number().int().min(0).max(99999999).openapi({
+    description:
+      'Consultation amount submitted by the client. Must exactly match the practice consultation fee for the provided slug.',
+    example: 15000,
+  }), // $0.00 to $999,999.99
   email: z.email().max(255),
   name: z.string().min(1).max(200),
   phone: z.string().max(50).optional(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Intake creation now validates that the submitted amount exactly matches the practice's consultation fee, returning an error if amounts don't align.

* **Documentation**
  * Added API documentation clarifying the amount validation requirement for intake submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->