### PR TITLE
feat: add practice service ID to client intake schema and update related services

### DIFF
--- a/src/modules/practice-client-intakes/database/schema/practice-client-intakes.schema.ts
+++ b/src/modules/practice-client-intakes/database/schema/practice-client-intakes.schema.ts
@@ -4,6 +4,7 @@ import { pgTable, uuid, text, integer, jsonb, timestamp, index, varchar, boolean
 
 import { stripeConnectedAccounts } from '@/modules/onboarding/schemas/onboarding.schema';
 import { addresses } from '@/modules/practice/database/schema/addresses.schema';
+import { practiceServices } from '@/modules/practice/database/schema/practice.schema';
 import { organizations } from '@/schema/better-auth-schema';
 
 import { addressSchema } from '@/shared/validations/address';
@@ -19,6 +20,9 @@ export const practiceClientIntakes = pgTable(
       .references(() => organizations.id, { onDelete: 'cascade' }),
     connected_account_id: uuid('connected_account_id').references(() => stripeConnectedAccounts.id, {
       onDelete: 'restrict',
+    }),
+    practice_service_id: uuid('practice_service_id').references(() => practiceServices.id, {
+      onDelete: 'set null',
     }),
 
     // Stripe IDs
@@ -65,6 +69,7 @@ export const practiceClientIntakes = pgTable(
     index('practice_client_intakes_stripe_intent_idx').on(table.stripe_payment_intent_id),
     index('practice_client_intakes_status_idx').on(table.status),
     index('practice_client_intakes_triage_status_idx').on(table.triage_status),
+    index('practice_client_intakes_practice_service_idx').on(table.practice_service_id),
     index('practice_client_intakes_created_at_idx').on(table.created_at),
     index('practice_client_intakes_urgency_idx').on(table.urgency),
     index('practice_client_intakes_court_date_idx').on(table.court_date),
@@ -84,6 +89,10 @@ export const practiceClientIntakesRelations = relations(practiceClientIntakes, (
     fields: [practiceClientIntakes.connected_account_id],
     references: [stripeConnectedAccounts.id],
   }),
+  practiceService: one(practiceServices, {
+    fields: [practiceClientIntakes.practice_service_id],
+    references: [practiceServices.id],
+  }),
   address: one(addresses, {
     fields: [practiceClientIntakes.address_id],
     references: [addresses.id],
@@ -101,6 +110,7 @@ export const practiceClientIntakeMetadataSchema = z
     opposing_party: z.string().optional(),
     opposing_counsel: z.string().optional(),
     description: z.string().optional(),
+    practice_service_uuid: z.uuid().optional(),
     address: addressSchema.optional(),
   })
   .openapi('PracticeClientIntakeMetadata');

--- a/src/modules/practice-client-intakes/services/intake-creation.service.ts
+++ b/src/modules/practice-client-intakes/services/intake-creation.service.ts
@@ -57,6 +57,11 @@ const getIntakeSettings = async (params: {
 
     const practiceDetails = await findPracticeDetailsByOrganization(organization.id);
     const consultationFee = practiceDetails?.consultation_fee ?? 0;
+    const serviceArea = (practiceDetails?.services ?? []).map((service) => ({
+      id: service.id,
+      name: service.name,
+      key: service.key,
+    }));
 
     return result.ok({
       success: true,
@@ -72,6 +77,7 @@ const getIntakeSettings = async (params: {
           // Keep FE display and create-intake amount consistent with the same backend source.
           consultation_fee: consultationFee,
         },
+        service_area: serviceArea,
         connected_account: {
           id: connectedAccount.id,
           charges_enabled: connectedAccount.charges_enabled,
@@ -115,6 +121,7 @@ const insertIntakeRecordTx = async (
     id: params.intakeId,
     organization_id: params.organizationId,
     connected_account_id: params.connectedAccountId,
+    practice_service_id: params.request.practice_service_uuid,
     stripe_payment_link_id: params.stripePaymentLinkId,
     address_id: addressId,
     conversation_id: params.request.conversation_id,
@@ -130,6 +137,7 @@ const insertIntakeRecordTx = async (
       on_behalf_of: params.request.on_behalf_of,
       opposing_party: params.request.opposing_party,
       description: params.request.description,
+      practice_service_uuid: params.request.practice_service_uuid,
       address: params.request.address,
       ...(params.validatedUserId && { user_id: params.validatedUserId }),
     },
@@ -159,6 +167,13 @@ const createIntake = async (params: { data: IntakeCreationRequest }): Promise<Re
 
     const practiceDetails = await findPracticeDetailsByOrganization(organization.id);
     const consultationFee = practiceDetails?.consultation_fee ?? 0;
+
+    if (
+      request.practice_service_uuid &&
+      !(practiceDetails?.services ?? []).some((service) => service.id === request.practice_service_uuid)
+    ) {
+      return result.badRequest('Selected practice service does not belong to this organization.');
+    }
 
     const requiresPayment = Boolean(organization.paymentLinkEnabled) && consultationFee > 0;
     // Backend is the source of truth for amount in create-intake flows.

--- a/src/modules/practice-client-intakes/types/practice-client-intakes.types.ts
+++ b/src/modules/practice-client-intakes/types/practice-client-intakes.types.ts
@@ -19,6 +19,7 @@ export type UpdateIntakeTriageStatusRequest = z.infer<typeof intakeValidations.u
 export interface IntakeSettings {
   payment_link_enabled: boolean;
   consultation_fee: number;
+  service_area: { id: string; name: string; key: string }[];
 }
 
 /**

--- a/src/modules/practice-client-intakes/validations/practice-client-intakes.validation.ts
+++ b/src/modules/practice-client-intakes/validations/practice-client-intakes.validation.ts
@@ -19,6 +19,10 @@ const createPracticeClientIntakeSchema = z.object({
   }),
   description: z.string().max(500).optional(),
   user_id: z.uuid().optional(),
+  practice_service_uuid: z.uuid().optional().openapi({
+    description: 'Optional practice service UUID selected by the client.',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  }),
   address: addressSchema.optional().openapi({
     description: 'Client address information',
   }),
@@ -88,6 +92,21 @@ const practiceClientIntakeSettingsResponseSchema = z.object({
             'Consultation fee (in cents) from practice_details.consultation_fee — backend source of truth for intake payment flows.',
         }),
       }),
+      service_area: z
+        .array(
+          z.object({
+            id: z.uuid(),
+            name: z.string(),
+            key: z.string(),
+          })
+        )
+        .openapi({
+          description: 'Practice services configured for the organization.',
+          example: [
+            { id: '9f7a2c1f-8e5c-4b8a-9d7f-1234567890ab', name: 'Family Law', key: 'FAMILY_LAW' },
+            { id: '7f7a2c1f-8e5c-4b8a-9d7f-1234567890cd', name: 'Immigration', key: 'IMMIGRATION' },
+          ],
+        }),
       connected_account: z.object({
         id: z.uuid(),
         charges_enabled: z.boolean(),
@@ -171,6 +190,7 @@ const practiceClientIntakeStatusResponseSchema = z.object({
           opposing_party: z.string().optional(),
           description: z.string().optional(),
           user_id: z.uuid().optional(),
+          practice_service_uuid: z.uuid().optional(),
           address: addressSchema.optional().openapi({
             example: {
               line1: '123 Client St',

--- a/src/modules/practice/database/queries/practice-details.repository.ts
+++ b/src/modules/practice/database/queries/practice-details.repository.ts
@@ -4,6 +4,7 @@ import {
   practiceDetails,
   type InsertPracticeDetails,
   type PracticeDetails,
+  type PracticeService,
 } from '@/modules/practice/database/schema/practice.schema';
 import { organizations } from '@/schema/better-auth-schema';
 import { db } from '@/shared/database';
@@ -15,14 +16,13 @@ export const createPracticeDetails = async (data: InsertPracticeDetails): Promis
 
 export const findPracticeDetailsByOrganization = async (
   organizationId: string
-): Promise<PracticeDetails | undefined> => {
-  const [practiceDetail] = await db
-    .select()
-    .from(practiceDetails)
-    .where(eq(practiceDetails.organization_id, organizationId))
-    .limit(1);
-  return practiceDetail;
-};
+): Promise<(PracticeDetails & { services: PracticeService[] }) | undefined> =>
+  await db.query.practiceDetails.findFirst({
+    where: (details) => eq(details.organization_id, organizationId),
+    with: {
+      services: true,
+    },
+  });
 
 export const findPracticeWithOrganization = async (
   organizationId: string


### PR DESCRIPTION
fixes #198 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Practice client intakes now support linking to specific practice services during creation
  * Available practice services are displayed in intake settings for easy selection and management
  * Selected service information is automatically captured and stored with each intake record
  * Built-in validation ensures only services from your organization can be selected for intakes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->