### PR TITLE
persist intake custom fields

### DIFF
--- a/src/modules/practice-client-intakes/database/schema/practice-client-intakes.schema.ts
+++ b/src/modules/practice-client-intakes/database/schema/practice-client-intakes.schema.ts
@@ -113,6 +113,7 @@ export const practiceClientIntakeMetadataSchema = z
     practice_service_name: z.string().optional(),
     practice_service_uuid: z.uuid().optional(),
     address: addressSchema.optional(),
+    custom_fields: z.record(z.string(), z.unknown()).optional(),
   })
   .openapi('PracticeClientIntakeMetadata');
 

--- a/src/modules/practice-client-intakes/services/intake-creation.service.ts
+++ b/src/modules/practice-client-intakes/services/intake-creation.service.ts
@@ -141,6 +141,7 @@ const insertIntakeRecordTx = async (
       practice_service_name: params.practiceServiceName,
       practice_service_uuid: params.request.practice_service_uuid,
       address: params.request.address,
+      custom_fields: params.request.custom_fields,
       ...(params.validatedUserId && { user_id: params.validatedUserId }),
     },
     client_ip: params.request.clientIp,

--- a/src/modules/practice-client-intakes/services/intake-shared.helpers.ts
+++ b/src/modules/practice-client-intakes/services/intake-shared.helpers.ts
@@ -43,6 +43,7 @@ const getAuthorizedMetadata = (metadata: PracticeClientIntakeMetadata | null, is
         on_behalf_of: metadata.on_behalf_of ?? undefined,
         opposing_party: metadata.opposing_party ?? undefined,
         description: metadata.description ?? undefined,
+        custom_fields: metadata.custom_fields ?? undefined,
       }
     : { email: '', name: '' };
 

--- a/src/modules/practice-client-intakes/validations/practice-client-intakes.validation.ts
+++ b/src/modules/practice-client-intakes/validations/practice-client-intakes.validation.ts
@@ -37,6 +37,9 @@ const createPracticeClientIntakeSchema = z.object({
   income: z.number().int().optional(),
   household_size: z.number().int().optional(),
   case_strength: z.number().min(0).max(1).optional(),
+  custom_fields: z.record(z.string(), z.unknown()).optional().openapi({
+    description: 'Template-defined intake answers that do not map to first-class intake columns.',
+  }),
 });
 
 const updatePracticeClientIntakeSchema = z.object({
@@ -191,6 +194,7 @@ const practiceClientIntakeStatusResponseSchema = z.object({
           description: z.string().optional(),
           user_id: z.uuid().optional(),
           practice_service_uuid: z.uuid().optional(),
+          custom_fields: z.record(z.string(), z.unknown()).optional(),
           address: addressSchema.optional().openapi({
             example: {
               line1: '123 Client St',
@@ -306,6 +310,7 @@ const listIntakesResponseSchema = z.object({
             on_behalf_of: z.string().optional(),
             opposing_party: z.string().optional(),
             description: z.string().optional(),
+            custom_fields: z.record(z.string(), z.unknown()).optional(),
           }),
           succeeded_at: z.date().nullable(),
           created_at: z.date(),


### PR DESCRIPTION
What changed\n- Accept custom_fields on the public practice-client-intake create payload.\n- Store custom_fields inside practice_client_intakes.metadata.\n- Return custom_fields in authorized intake metadata responses for detail and list views.\n\nWhy\n- The chatbot can now collect template-defined custom answers. This backend change preserves unmapped custom answers instead of dropping them at intake submission.\n\nValidation\n- pnpm exec oxlint src/modules/practice-client-intakes/database/schema/practice-client-intakes.schema.ts src/modules/practice-client-intakes/validations/practice-client-intakes.validation.ts src/modules/practice-client-intakes/services/intake-creation.service.ts src/modules/practice-client-intakes/services/intake-shared.helpers.ts\n- pnpm run typecheck currently fails on staging with: src/schema/index.ts(53,15): Cannot find module './oauth.schema' or its corresponding type declarations.\n- pnpm run lint is not currently usable as a repo-wide gate on staging due existing unrelated lint failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Practice client intakes now support custom fields, allowing users to store and retrieve additional metadata during intake submission and view operations with proper access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->