### PR TITLE
fix: allow all preference categories to be updated via PUT endpoint

### DIFF
--- a/src/modules/preferences/handlers.ts
+++ b/src/modules/preferences/handlers.ts
@@ -4,41 +4,50 @@
  * HTTP route handlers for preferences API endpoints
  */
 
+import { z } from '@hono/zod-openapi';
 import type { Context } from 'hono';
 import { preferencesService } from './services/preferences.service';
 import { PREFERENCE_CATEGORIES, type PreferenceCategory } from '@/modules/preferences/types/preferences.types';
 import { preferenceValidations } from '@/modules/preferences/validations/preferences.validation';
 import { getServiceContext } from '@/shared/types/service-context';
+import { validator } from '@/shared/validations/hono-validation';
 
-/**
- * Type guard to validate preference category
- */
 const isValidPreferenceCategory = (category: string): category is PreferenceCategory =>
   PREFERENCE_CATEGORIES.some((value) => value === category);
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === 'object' && !Array.isArray(value);
 
-const isValidCategoryPayload = (category: PreferenceCategory, payload: unknown): payload is Record<string, unknown> => {
-  if (!isRecord(payload)) {
-    return false;
-  }
+const parseCategoryPayload = (category: PreferenceCategory, payload: unknown): Record<string, unknown> | null => {
+  if (!isRecord(payload)) return null;
 
   switch (category) {
-    case 'general':
-      return preferenceValidations.generalPreferencesSchema.safeParse(payload).success;
-    case 'notifications':
-      return preferenceValidations.notificationPreferencesSchema.safeParse(payload).success;
-    case 'security':
-      return preferenceValidations.securityPreferencesSchema.safeParse(payload).success;
-    case 'account':
-      return preferenceValidations.accountPreferencesSchema.safeParse(payload).success;
-    case 'onboarding':
-      return preferenceValidations.onboardingPreferencesSchema.safeParse(payload).success;
-    case 'profile':
-      return preferenceValidations.profilePreferencesSchema.safeParse(payload).success;
+    case 'general': {
+      const result = preferenceValidations.generalPreferencesSchema.safeParse(payload);
+      return result.success ? result.data : null;
+    }
+    case 'notifications': {
+      const result = preferenceValidations.notificationPreferencesSchema.safeParse(payload);
+      return result.success ? result.data : null;
+    }
+    case 'security': {
+      const result = preferenceValidations.securityPreferencesSchema.safeParse(payload);
+      return result.success ? result.data : null;
+    }
+    case 'account': {
+      const result = preferenceValidations.accountPreferencesSchema.safeParse(payload);
+      return result.success ? result.data : null;
+    }
+    case 'onboarding': {
+      const result = preferenceValidations.onboardingPreferencesSchema.safeParse(payload);
+      return result.success ? result.data : null;
+    }
+    case 'profile': {
+      const result = preferenceValidations.profilePreferencesSchema.safeParse(payload);
+      return result.success ? result.data : null;
+    }
     default:
-      return false;
+      return null;
   }
 };
 
@@ -58,7 +67,6 @@ const getCategoryPreferences = async (c: Context) => {
   const ctx = getServiceContext(c);
   const categoryParam = c.req.param('category');
 
-  // Validate category exists and is one of the allowed values
   if (!categoryParam || !isValidPreferenceCategory(categoryParam)) {
     return c.json({ error: 'Invalid category' }, 400);
   }
@@ -73,29 +81,24 @@ const getCategoryPreferences = async (c: Context) => {
 const updateCategoryPreferences = async (c: Context) => {
   const ctx = getServiceContext(c);
   const categoryParam = c.req.param('category');
-  const validatedBody = (await c.req.json()) as unknown;
 
-  // Validate category exists and is one of the allowed values
   if (!categoryParam || !isValidPreferenceCategory(categoryParam)) {
     return c.json({ error: 'Invalid category' }, 400);
   }
 
-  if (!isValidCategoryPayload(categoryParam, validatedBody)) {
+  const rawBody = await validator.validateBody(c, z.record(z.string(), z.unknown()));
+  const parsed = parseCategoryPayload(categoryParam, rawBody);
+
+  if (!parsed) {
     return c.json({ error: 'Invalid preferences payload' }, 400);
   }
 
-  const result = await preferencesService.updatePreferencesByCategory(categoryParam, validatedBody, ctx);
-
+  const result = await preferencesService.updatePreferencesByCategory(categoryParam, parsed, ctx);
   return c.json(result);
 };
 
-/**
- * Preferences Handlers
- */
 export const preferencesHandlers = {
   getAllPreferences,
   getCategoryPreferences,
   updateCategoryPreferences,
 };
-
-export default preferencesHandlers;

--- a/src/modules/preferences/handlers.ts
+++ b/src/modules/preferences/handlers.ts
@@ -73,7 +73,7 @@ const getCategoryPreferences = async (c: Context) => {
 const updateCategoryPreferences = async (c: Context) => {
   const ctx = getServiceContext(c);
   const categoryParam = c.req.param('category');
-  const validatedBody = c.get('validatedBody');
+  const validatedBody = (await c.req.json()) as unknown;
 
   // Validate category exists and is one of the allowed values
   if (!categoryParam || !isValidPreferenceCategory(categoryParam)) {

--- a/src/modules/preferences/routes.ts
+++ b/src/modules/preferences/routes.ts
@@ -83,9 +83,9 @@ export const updateCategoryPreferencesRoute = routeBuilder.build({
     body: {
       content: {
         'application/json': {
-          schema: preferenceValidations.notificationPreferencesSchema.openapi({
+          schema: z.record(z.string(), z.unknown()).openapi({
             description:
-              'Category-specific preferences data. Schema depends on the category parameter. Example shown is for notifications category. Supports partial updates - only include fields you want to change. Note: For notifications category, system_push and system_email are always set to true regardless of input.',
+              'Category-specific preferences data. Schema depends on the category parameter. Supports partial updates - only include fields you want to change. For notifications category, system_push and system_email are always set to true regardless of input.',
             example: {
               messages_push: true,
               messages_email: true,


### PR DESCRIPTION
The PUT /api/preferences/:category route had its OpenAPI body schema hard-coded to notificationPreferencesSchema, causing Zod validation to reject payloads for any other category (onboarding, general, etc.) before the handler ran. The handler also read from c.get('validatedBody') which was never populated since no validateJson middleware was wired up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Made the preferences API more flexible in accepting request body formats.
* **Documentation**
  * Clarified that system push and email notifications remain enabled for the notifications category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->