### PR TITLE
fix: return 200 with default payload instead of 404 for missing onboarding status

### DIFF
--- a/src/modules/onboarding/routes.ts
+++ b/src/modules/onboarding/routes.ts
@@ -23,14 +23,6 @@ export const getOnboardingStatusRoute = routeBuilder.build({
       },
       description: 'Onboarding status retrieved successfully',
     },
-    404: {
-      content: {
-        'application/json': {
-          schema: onboardingValidations.notFoundResponseSchema,
-        },
-      },
-      description: 'Onboarding status not found',
-    },
     400: {
       content: {
         'application/json': {

--- a/src/modules/onboarding/services/onboarding.service.ts
+++ b/src/modules/onboarding/services/onboarding.service.ts
@@ -105,7 +105,16 @@ const onboardingService = {
       const account = await onboardingRepo.findByOrganizationId(organizationId);
 
       if (!account) {
-        return notFound(`Onboarding status not found for organization ${organizationId}`);
+        // Return default "not started" status instead of 404
+        // This is a valid business state, not an error
+        return ok({
+          practice_uuid: organizationId,
+          connected_account_id: null,
+          stripe_account_id: null,
+          charges_enabled: false,
+          payouts_enabled: false,
+          details_submitted: false,
+        });
       }
 
       return ok({

--- a/src/modules/onboarding/validations/onboarding.validation.ts
+++ b/src/modules/onboarding/validations/onboarding.validation.ts
@@ -161,10 +161,10 @@ export const onboardingStatusResponseSchema = z
     practice_uuid: z.uuid().openapi({
       example: '123e4567-e89b-12d3-a456-426614174000',
     }),
-    connected_account_id: z.uuid().openapi({
+    connected_account_id: z.uuid().nullable().openapi({
       example: '123e4567-e89b-12d3-a456-426614174000',
     }),
-    stripe_account_id: z.string().openapi({
+    stripe_account_id: z.string().nullable().openapi({
       example: 'acct_1234567890',
     }),
     charges_enabled: z.boolean().openapi({


### PR DESCRIPTION
## Problem
The GET /api/onboarding/organization/{id}/status endpoint returns 404 when an organization doesn't have a Stripe onboarding record. This causes browser console errors and forces frontend components to handle error cases for what should be a valid business state.

## Solution
Update the endpoint to return 200 OK with a default "not started" payload when no onboarding record exists, treating it as a valid business state rather than an error.

## Changes
- **Service**: Modified  to return default payload with null values instead of 404
- **API**: Removed 404 response from OpenAPI route definition  
- **Schema**: Made  and  nullable in validation schema

## Impact
- Eliminates browser console errors for organizations that haven't started onboarding
- Removes need for frontend error handling in components like  and 
- Follows fail-fast principle by treating "not started" as valid state

## Testing
Manual testing shows the endpoint now returns:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed onboarding status endpoint to return a default "not started" state when no onboarding record exists for an organization, instead of returning an error response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->