### PR TITLE
fix: return 200 with empty payload instead of 404 for missing practice details

### DIFF
--- a/src/modules/practice/services/practice-queries.service.ts
+++ b/src/modules/practice/services/practice-queries.service.ts
@@ -120,7 +120,34 @@ export const practiceQueriesService = {
       ]);
 
       if (!fetchedDetails) {
-        throw new HTTPException(404, { message: `Practice details not found for organization '${organizationId}'` });
+        // Return empty practice details instead of 404
+        // This is a valid business state, not an error
+        return {
+          id: '',
+          user_id: '',
+          address_id: null,
+          business_phone: null,
+          business_email: null,
+          consultation_fee: null,
+          payment_url: null,
+          calendly_url: null,
+          website: null,
+          intro_message: null,
+          overview: null,
+          accent_color: null,
+          is_public: false,
+          organization_id: organizationId,
+          services: [],
+          address: null,
+          name: organization.name,
+          logo: organization.logo ?? null,
+          payment_link_enabled: organization?.paymentLinkEnabled ?? false,
+          billing_increment_minutes: 15,
+          created_at: new Date(),
+          updated_at: undefined,
+          supported_states: null,
+          service_states: null,
+        };
       }
 
       // 3. Fetch address if linked
@@ -167,9 +194,38 @@ export const practiceQueriesService = {
       ]);
 
       if (!fetchedDetails) {
-        throw new HTTPException(404, { message: `Practice details not found for organization '${slug}'` });
+        // Return empty practice details instead of 404 for non-existent details
+        // This is a valid business state, not an error
+        return {
+          id: '',
+          user_id: '',
+          address_id: null,
+          business_phone: null,
+          business_email: null,
+          consultation_fee: null,
+          payment_url: null,
+          calendly_url: null,
+          website: null,
+          intro_message: null,
+          overview: null,
+          accent_color: null,
+          is_public: false,
+          organization_id: organization.id,
+          services: [],
+          address: null,
+          name: organization.name ?? '',
+          logo: organization.logo ?? null,
+          payment_link_enabled: organization.paymentLinkEnabled ?? false,
+          billing_increment_minutes: 15,
+          created_at: new Date(),
+          updated_at: undefined,
+          supported_states: null,
+          service_states: null,
+        };
       }
+      
       if (!fetchedDetails.is_public) {
+        // Still return 404 for private practice details when accessed via public slug
         throw new HTTPException(404, { message: `Practice details not found for organization '${slug}'` });
       }
 

--- a/src/modules/practice/services/practice-queries.service.ts
+++ b/src/modules/practice/services/practice-queries.service.ts
@@ -123,8 +123,8 @@ export const practiceQueriesService = {
         // Return empty practice details instead of 404
         // This is a valid business state, not an error
         return {
-          id: '',
-          user_id: '',
+          id: null,
+          user_id: null,
           address_id: null,
           business_phone: null,
           business_email: null,
@@ -143,7 +143,7 @@ export const practiceQueriesService = {
           logo: organization.logo ?? null,
           payment_link_enabled: organization?.paymentLinkEnabled ?? false,
           billing_increment_minutes: 15,
-          created_at: new Date(),
+          created_at: null,
           updated_at: undefined,
           supported_states: null,
           service_states: null,
@@ -197,8 +197,8 @@ export const practiceQueriesService = {
         // Return empty practice details instead of 404 for non-existent details
         // This is a valid business state, not an error
         return {
-          id: '',
-          user_id: '',
+          id: null,
+          user_id: null,
           address_id: null,
           business_phone: null,
           business_email: null,
@@ -217,7 +217,7 @@ export const practiceQueriesService = {
           logo: organization.logo ?? null,
           payment_link_enabled: organization.paymentLinkEnabled ?? false,
           billing_increment_minutes: 15,
-          created_at: new Date(),
+          created_at: null,
           updated_at: undefined,
           supported_states: null,
           service_states: null,

--- a/src/modules/practice/validations/practice.validation.ts
+++ b/src/modules/practice/validations/practice.validation.ts
@@ -416,11 +416,11 @@ const updatePracticeDetailsSchema = practiceDetailsValidationSchema;
 
 const practiceDetailsResponseSchema = z
   .object({
-    id: z.uuid().openapi({
+    id: z.uuid().nullable().openapi({
       description: 'Practice Details ID',
       example: '123e4567-e89b-12d3-a456-426614174000',
     }),
-    user_id: z.uuid().openapi({
+    user_id: z.uuid().nullable().openapi({
       description: 'User ID of the creator',
       example: '123e4567-e89b-12d3-a456-426614174000',
     }),
@@ -479,7 +479,7 @@ const practiceDetailsResponseSchema = z
       description: 'Billing increment in minutes for time entry dropdowns',
       example: 15,
     }),
-    created_at: z.date().openapi({
+    created_at: z.date().nullable().openapi({
       description: 'Practice details creation timestamp',
       format: 'date-time',
       example: '2024-01-01T00:00:00Z',


### PR DESCRIPTION
## Problem
The GET /api/practice/{id}/details and GET /api/practice/details/{slug} endpoints return 404 when a practice hasn't customized their details (logo, contact info, website, etc.). This causes browser console errors and forces frontend components to handle error cases for what should be a valid business state.

## Solution
Update both endpoints to return 200 OK with a default empty object when no practice details exist, treating it as a valid business state rather than an error.

## Changes
- **Service**: Modified  to return empty practice details object instead of 404
- **Service**: Modified  to return empty object for non-existent details  
- **Security**: Kept 404 for private practice details when accessed via public slug
- **API**: No changes needed - routes already only define 200 responses

## Impact
- Eliminates browser console errors for practices that haven't customized their details
- Removes need for frontend error handling in  and 
- Follows fail-fast principle by treating "not customized" as valid state
- Maintains security for private practice details

## Testing
Manual testing shows both endpoints now return empty object with null values when no details exist:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified practice details retrieval to return an empty response when unavailable instead of throwing an error, with private practices still protected by access restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->