### PR TITLE
feat: Clio gap report endpoints for Worker consumption (Phase 3, #233)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,7 +291,7 @@ Transform tasks into verifiable goals:
 
 For multi-step tasks, state a brief plan:
 
-```
+```text
 1. [Step] → verify: [check]
 2. [Step] → verify: [check]
 3. [Step] → verify: [check]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,3 +231,74 @@ Laravel-inspired: define event classes extending `BaseEvent<T>`, dispatch via `c
 2. Run `pnpm run format:check` to verify formatting
 3. If you created a new schema, run `pnpm run db:generate`
 4. Check for dead imports and unused code
+
+## Behavioral Guidelines
+
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+### 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+### 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+### 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+### 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/src/modules/matters/database/queries/matter-tasks.queries.ts
+++ b/src/modules/matters/database/queries/matter-tasks.queries.ts
@@ -1,11 +1,12 @@
-import { and, asc, eq } from 'drizzle-orm';
+import { and, asc, desc, eq, getTableColumns, isNull, lt } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import {
   matterTasks,
   type InsertMatterTask,
   type SelectMatterTask,
 } from '@/modules/matters/database/schema/matter-tasks.schema';
-import type { MatterTaskListFilters } from '@/modules/matters/types/matter-filters.types';
+import { matters } from '@/modules/matters/database/schema/matters.schema';
+import type { MatterTaskListFilters, OrgTaskListFilters } from '@/modules/matters/types/matter-filters.types';
 import type * as schema from '@/schema';
 import { db } from '@/shared/database';
 
@@ -67,10 +68,41 @@ const deleteMatterTask = async (id: string): Promise<boolean> => {
   return rows.length > 0;
 };
 
+/**
+ * List tasks across an organization, joined to matters for org scoping
+ * and to exclude soft-deleted matters.
+ *
+ * due_before semantics: `due_date < due_before` — excludes tasks with NULL due_date.
+ */
+const listTasksByOrganization = async (
+  organizationId: string,
+  filters?: OrgTaskListFilters
+): Promise<SelectMatterTask[]> => {
+  const conditions = [eq(matters.organization_id, organizationId), isNull(matters.deleted_at)];
+
+  if (filters?.assigneeId) {
+    conditions.push(eq(matterTasks.assignee_id, filters.assigneeId));
+  }
+  if (filters?.status) {
+    conditions.push(eq(matterTasks.status, filters.status));
+  }
+  if (filters?.dueBefore) {
+    conditions.push(lt(matterTasks.due_date, filters.dueBefore));
+  }
+
+  return await db
+    .select(getTableColumns(matterTasks))
+    .from(matterTasks)
+    .innerJoin(matters, eq(matterTasks.matter_id, matters.id))
+    .where(and(...conditions))
+    .orderBy(desc(matterTasks.created_at));
+};
+
 export const matterTasksQueries = {
   createMatterTasks,
   findMatterTaskById,
   listMatterTasks,
+  listTasksByOrganization,
   updateMatterTask,
   deleteMatterTask,
 };

--- a/src/modules/matters/database/queries/matter-tasks.queries.ts
+++ b/src/modules/matters/database/queries/matter-tasks.queries.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, getTableColumns, isNull, lt } from 'drizzle-orm';
+import { and, asc, count, desc, eq, getTableColumns, isNull, lt } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import {
   matterTasks,
@@ -77,7 +77,11 @@ const deleteMatterTask = async (id: string): Promise<boolean> => {
 const listTasksByOrganization = async (
   organizationId: string,
   filters?: OrgTaskListFilters
-): Promise<SelectMatterTask[]> => {
+): Promise<{ data: SelectMatterTask[]; total: number; page: number; limit: number }> => {
+  const page = filters?.page ?? 1;
+  const limit = filters?.limit ?? 20;
+  const offset = (page - 1) * limit;
+
   const conditions = [eq(matters.organization_id, organizationId), isNull(matters.deleted_at)];
 
   if (filters?.assigneeId) {
@@ -90,12 +94,25 @@ const listTasksByOrganization = async (
     conditions.push(lt(matterTasks.due_date, filters.dueBefore));
   }
 
-  return await db
-    .select(getTableColumns(matterTasks))
-    .from(matterTasks)
-    .innerJoin(matters, eq(matterTasks.matter_id, matters.id))
-    .where(and(...conditions))
-    .orderBy(desc(matterTasks.created_at));
+  const whereClause = and(...conditions);
+
+  const [tasks, [countRow]] = await Promise.all([
+    db
+      .select(getTableColumns(matterTasks))
+      .from(matterTasks)
+      .innerJoin(matters, eq(matterTasks.matter_id, matters.id))
+      .where(whereClause)
+      .orderBy(desc(matterTasks.created_at))
+      .limit(limit)
+      .offset(offset),
+    db
+      .select({ total: count() })
+      .from(matterTasks)
+      .innerJoin(matters, eq(matterTasks.matter_id, matters.id))
+      .where(whereClause),
+  ]);
+
+  return { data: tasks, total: Number(countRow?.total ?? 0), page, limit };
 };
 
 export const matterTasksQueries = {

--- a/src/modules/matters/database/queries/matter-time-entries.queries.ts
+++ b/src/modules/matters/database/queries/matter-time-entries.queries.ts
@@ -1,4 +1,4 @@
-import { eq, and, desc, gte, lte, sql, inArray, isNull } from 'drizzle-orm';
+import { eq, and, desc, gte, lte, sql, inArray, isNull, isNotNull } from 'drizzle-orm';
 import {
   matterTimeEntries,
   type InsertMatterTimeEntry,
@@ -32,6 +32,10 @@ const listMatterTimeEntries = async (
 
   if (filters?.billable !== undefined) {
     conditions.push(eq(matterTimeEntries.billable, filters.billable));
+  }
+
+  if (filters?.invoiced !== undefined) {
+    conditions.push(filters.invoiced ? isNotNull(matterTimeEntries.invoice_id) : isNull(matterTimeEntries.invoice_id));
   }
 
   if (filters?.startDate) {

--- a/src/modules/matters/database/queries/matters.queries.ts
+++ b/src/modules/matters/database/queries/matters.queries.ts
@@ -102,6 +102,14 @@ const listMattersByOrganization = async (
     conditions.push(eq(matters.id, filters.matterId));
   }
 
+  if (filters?.responsibleAttorneyId) {
+    conditions.push(eq(matters.responsible_attorney_id, filters.responsibleAttorneyId));
+  }
+
+  if (filters?.originatingAttorneyId) {
+    conditions.push(eq(matters.originating_attorney_id, filters.originatingAttorneyId));
+  }
+
   if (filters?.search) {
     conditions.push(like(matters.title, `%${filters.search}%`));
   }
@@ -195,6 +203,36 @@ const getMatterCountsByStatus = async (organizationId: string): Promise<{ status
     .where(and(eq(matters.organization_id, organizationId), isNull(matters.deleted_at)))
     .groupBy(matters.status);
 
+// Get matters summary grouped by originating attorney
+const getMattersSummaryByOriginatingAttorney = async (
+  organizationId: string
+): Promise<
+  {
+    originating_attorney_id: string | null;
+    total_matters: number;
+    active_matters: number;
+    closed_matters: number;
+  }[]
+> => {
+  const rows = await db
+    .select({
+      originating_attorney_id: matters.originating_attorney_id,
+      total_matters: sql<number>`count(*)::int`,
+      active_matters: sql<number>`count(*) FILTER (WHERE ${matters.status} <> 'closed')::int`,
+      closed_matters: sql<number>`count(*) FILTER (WHERE ${matters.status} = 'closed')::int`,
+    })
+    .from(matters)
+    .where(and(eq(matters.organization_id, organizationId), isNull(matters.deleted_at)))
+    .groupBy(matters.originating_attorney_id);
+
+  return rows.map((r) => ({
+    originating_attorney_id: r.originating_attorney_id,
+    total_matters: Number(r.total_matters),
+    active_matters: Number(r.active_matters),
+    closed_matters: Number(r.closed_matters),
+  }));
+};
+
 // Add assignees to matter
 const addMatterAssignees = async (matterId: string, userIds: string[], tx?: typeof db): Promise<void> => {
   if (userIds.length === 0) {
@@ -272,6 +310,7 @@ export const mattersQueries = {
   softDeleteMatter,
   deleteMatter,
   getMatterCountsByStatus,
+  getMattersSummaryByOriginatingAttorney,
   findMatterByIdWithRelations,
   findMatterByIdWithDeleted,
   listMattersByOrganization,

--- a/src/modules/matters/handlers.ts
+++ b/src/modules/matters/handlers.ts
@@ -21,16 +21,27 @@ const createMatterHandler: AppRouteHandler<typeof matterRoutes.createMatterRoute
 const listMattersHandler: AppRouteHandler<typeof matterRoutes.listMattersRoute> = async (c) => {
   const ctx = getServiceContext(c);
   const query = c.req.valid('query');
-  const page = parseInt(String(query.page ?? '1'), 10);
-  const limit = parseInt(String(query.limit ?? '20'), 10);
-  const data = await mattersService.listMatters({ ...query, page, limit }, ctx);
+  const data = await mattersService.listMatters(
+    {
+      status: query.status,
+      practiceServiceId: query.practice_service_id,
+      clientId: query.client_id,
+      assigneeId: query.assignee_id,
+      responsibleAttorneyId: query.responsible_attorney_id,
+      originatingAttorneyId: query.originating_attorney_id,
+      search: query.search,
+      page: query.page,
+      limit: query.limit,
+    },
+    ctx
+  );
   return c.json(
     {
       matters: data.matters,
       total: data.total,
-      page,
-      limit,
-      totalPages: Math.ceil(data.total / limit),
+      page: query.page,
+      limit: query.limit,
+      totalPages: Math.ceil(data.total / query.limit),
     },
     200
   );
@@ -357,9 +368,11 @@ const listOrganizationTasksHandler: AppRouteHandler<typeof matterRoutes.listOrga
     assigneeId: query.assignee_id,
     status: query.status,
     dueBefore: query.due_before,
+    page: query.page,
+    limit: query.limit,
   };
-  const tasks = await matterTasksService.listOrganizationTasks({ filters }, ctx);
-  return c.json(tasks, 200);
+  const result = await matterTasksService.listOrganizationTasks({ filters }, ctx);
+  return c.json(result, 200);
 };
 
 export const handlers = {

--- a/src/modules/matters/handlers.ts
+++ b/src/modules/matters/handlers.ts
@@ -7,7 +7,7 @@ import { matterTasksService } from '@/modules/matters/services/matter-tasks.serv
 import { matterTimeEntriesService } from '@/modules/matters/services/matter-time-entries.service';
 import { matterFilesService } from '@/modules/matters/services/matter-files.service';
 import { mattersService } from '@/modules/matters/services/matters.service';
-import type { MatterTaskListFilters } from '@/modules/matters/types/matter-filters.types';
+import type { MatterTaskListFilters, OrgTaskListFilters } from '@/modules/matters/types/matter-filters.types';
 import type { AppRouteHandler } from '@/shared/types/hono';
 import { createServiceContext, getServiceContext } from '@/shared/types/service-context';
 
@@ -116,6 +116,7 @@ const listTimeEntriesHandler: AppRouteHandler<typeof matterRoutes.listTimeEntrie
     {
       filters: {
         billable: query.billable,
+        invoiced: query.invoiced,
         startDate: query.start_date,
         endDate: query.end_date,
         entryId: query.entry_id,
@@ -341,6 +342,26 @@ const unlinkMatterFileHandler: AppRouteHandler<typeof matterRoutes.unlinkMatterF
   return c.body(null, 204);
 };
 
+const getMattersSummaryByOriginatingAttorneyHandler: AppRouteHandler<
+  typeof matterRoutes.getMattersSummaryByOriginatingAttorneyRoute
+> = async (c) => {
+  const ctx = getServiceContext(c);
+  const summary = await mattersService.getMattersSummaryByOriginatingAttorney({}, ctx);
+  return c.json(summary, 200);
+};
+
+const listOrganizationTasksHandler: AppRouteHandler<typeof matterRoutes.listOrganizationTasksRoute> = async (c) => {
+  const ctx = getServiceContext(c);
+  const query = c.req.valid('query');
+  const filters: OrgTaskListFilters = {
+    assigneeId: query.assignee_id,
+    status: query.status,
+    dueBefore: query.due_before,
+  };
+  const tasks = await matterTasksService.listOrganizationTasks({ filters }, ctx);
+  return c.json(tasks, 200);
+};
+
 export const handlers = {
   listMattersHandler,
   getMatterHandler,
@@ -370,6 +391,8 @@ export const handlers = {
   createMatterTaskHandler,
   updateMatterTaskHandler,
   deleteMatterTaskHandler,
+  listOrganizationTasksHandler,
+  getMattersSummaryByOriginatingAttorneyHandler,
   getMatterUnbilledHandler,
   linkMatterFileHandler,
   listMatterFilesHandler,

--- a/src/modules/matters/http.ts
+++ b/src/modules/matters/http.ts
@@ -14,6 +14,17 @@ app.use('*', injectAbility());
 // Core matter routes (have their own access checks in services)
 app.openapi(matterRoutes.createMatterRoute, matterHandlers.createMatterHandler);
 app.openapi(matterRoutes.listMattersRoute, matterHandlers.listMattersHandler);
+
+// Org-scoped sub-resources — MUST be registered BEFORE the `/:practice_id` sub-router
+// so Hono's matcher prefers these literal paths over the wildcard `/:practice_id/:id/*`
+// that requireMatterAccess() guards (which would reject literals like "tasks" / "summary"
+// as invalid matter UUIDs).
+app.openapi(
+  matterRoutes.getMattersSummaryByOriginatingAttorneyRoute,
+  matterHandlers.getMattersSummaryByOriginatingAttorneyHandler
+);
+app.openapi(matterRoutes.listOrganizationTasksRoute, matterHandlers.listOrganizationTasksHandler);
+
 app.openapi(matterRoutes.getMatterRoute, matterHandlers.getMatterHandler);
 app.openapi(matterRoutes.updateMatterRoute, matterHandlers.updateMatterHandler);
 app.openapi(matterRoutes.deleteMatterRoute, matterHandlers.deleteMatterHandler);

--- a/src/modules/matters/routes/core.routes.ts
+++ b/src/modules/matters/routes/core.routes.ts
@@ -170,3 +170,38 @@ export const deleteMatterRoute = routeBuilder.build({
     },
   },
 });
+
+const mattersSummaryByOriginatingAttorneyItemSchema = z
+  .object({
+    originating_attorney_id: z.uuid().nullable(),
+    total_matters: z.number().int().min(0),
+    active_matters: z.number().int().min(0),
+    closed_matters: z.number().int().min(0),
+  })
+  .openapi('MattersSummaryByOriginatingAttorney', {
+    description: 'Aggregate matter counts grouped by originating attorney',
+  });
+
+export const getMattersSummaryByOriginatingAttorneyRoute = routeBuilder.build({
+  method: 'get',
+  path: '/{practice_id}/summary/by-originating-attorney',
+  tags,
+  summary: 'Matters summary by originating attorney',
+  description:
+    'Returns aggregate counts of total, active (status <> closed), and closed (status = closed) matters grouped by originating_attorney_id. Excludes soft-deleted matters.',
+  request: {
+    params: z.object({
+      practice_id: z.uuid(),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Matters summary retrieved successfully',
+      content: {
+        'application/json': {
+          schema: z.array(mattersSummaryByOriginatingAttorneyItemSchema),
+        },
+      },
+    },
+  },
+});

--- a/src/modules/matters/routes/index.ts
+++ b/src/modules/matters/routes/index.ts
@@ -5,6 +5,7 @@ import {
   getMatterRoute,
   updateMatterRoute,
   deleteMatterRoute,
+  getMattersSummaryByOriginatingAttorneyRoute,
 } from '@/modules/matters/routes/core.routes';
 import {
   listExpensesRoute,
@@ -30,6 +31,7 @@ import {
   createMatterTaskRoute,
   updateMatterTaskRoute,
   deleteMatterTaskRoute,
+  listOrganizationTasksRoute,
 } from '@/modules/matters/routes/tasks.routes';
 import {
   linkMatterFileRoute,
@@ -52,6 +54,7 @@ export const routes = {
   getMatterRoute,
   updateMatterRoute,
   deleteMatterRoute,
+  getMattersSummaryByOriginatingAttorneyRoute,
   getMatterActivityRoute,
   getTimeEntryStatsRoute,
   listTimeEntriesRoute,
@@ -75,6 +78,7 @@ export const routes = {
   createMatterTaskRoute,
   updateMatterTaskRoute,
   deleteMatterTaskRoute,
+  listOrganizationTasksRoute,
   getMatterUnbilledRoute,
   linkMatterFileRoute,
   listMatterFilesRoute,

--- a/src/modules/matters/routes/tasks.routes.ts
+++ b/src/modules/matters/routes/tasks.routes.ts
@@ -5,7 +5,9 @@ import {
   matterTaskResponseSchema,
   listMatterTasksQuerySchema,
 } from '@/modules/matters/types/matter.types';
+import { matterTaskValidations } from '@/modules/matters/validations/matter-tasks.validation';
 import { routeBuilder } from '@/shared/router/route-builder';
+import { uuidValidator } from '@/shared/validations/common';
 
 const tags = ['Matters'];
 
@@ -15,6 +17,16 @@ const matterIdParamSchema = z.object({
 
 const taskIdParamSchema = z.object({
   task_id: z.uuid(),
+});
+
+const practiceIdOnlyParamSchema = z.object({
+  practice_id: z.uuid(),
+});
+
+const listOrganizationTasksQuerySchema = z.object({
+  assignee_id: uuidValidator.optional(),
+  status: matterTaskValidations.taskStatusEnum.optional(),
+  due_before: z.iso.date().optional(),
 });
 
 export const listMatterTasksRoute = routeBuilder.build({
@@ -105,6 +117,29 @@ export const deleteMatterTaskRoute = routeBuilder.build({
   responses: {
     204: {
       description: 'Task deleted successfully',
+    },
+  },
+});
+
+export const listOrganizationTasksRoute = routeBuilder.build({
+  method: 'get',
+  path: '/{practice_id}/tasks',
+  tags,
+  summary: 'List tasks across the organization',
+  description:
+    'Returns tasks across the organization, joined to matters for org scoping. Supports filtering by assignee_id, status, and due_before. due_before semantics: due_date < due_before (excludes tasks with NULL due_date). Ordered by created_at DESC.',
+  request: {
+    params: practiceIdOnlyParamSchema,
+    query: listOrganizationTasksQuerySchema,
+  },
+  responses: {
+    200: {
+      description: 'Organization-wide tasks retrieved successfully',
+      content: {
+        'application/json': {
+          schema: z.array(matterTaskResponseSchema),
+        },
+      },
     },
   },
 });

--- a/src/modules/matters/routes/tasks.routes.ts
+++ b/src/modules/matters/routes/tasks.routes.ts
@@ -7,7 +7,8 @@ import {
 } from '@/modules/matters/types/matter.types';
 import { matterTaskValidations } from '@/modules/matters/validations/matter-tasks.validation';
 import { routeBuilder } from '@/shared/router/route-builder';
-import { uuidValidator } from '@/shared/validations/common';
+import { uuidValidator, paginationSchema as paginationQuerySchema } from '@/shared/validations/common';
+import { paginationSchema as paginationResponseSchema } from '@/shared/validations/openapi';
 
 const tags = ['Matters'];
 
@@ -27,6 +28,7 @@ const listOrganizationTasksQuerySchema = z.object({
   assignee_id: uuidValidator.optional(),
   status: matterTaskValidations.taskStatusEnum.optional(),
   due_before: z.iso.date().optional(),
+  ...paginationQuerySchema.shape,
 });
 
 export const listMatterTasksRoute = routeBuilder.build({
@@ -137,7 +139,10 @@ export const listOrganizationTasksRoute = routeBuilder.build({
       description: 'Organization-wide tasks retrieved successfully',
       content: {
         'application/json': {
-          schema: z.array(matterTaskResponseSchema),
+          schema: z.object({
+            data: z.array(matterTaskResponseSchema),
+            pagination: paginationResponseSchema,
+          }),
         },
       },
     },

--- a/src/modules/matters/services/matter-tasks.service.ts
+++ b/src/modules/matters/services/matter-tasks.service.ts
@@ -6,6 +6,7 @@ import { matterActivityService } from '@/modules/matters/services/matter-activit
 import { mattersService } from '@/modules/matters/services/matters.service';
 import type { MatterTaskListFilters, OrgTaskListFilters } from '@/modules/matters/types/matter-filters.types';
 import type { CreateMatterTaskRequest, UpdateMatterTaskRequest } from '@/modules/matters/types/matter.types';
+import type { OffsetPaginatedResponse } from '@/shared/types/pagination';
 import type { ServiceContext } from '@/shared/types/service-context';
 
 const createMatterTask = async (
@@ -156,9 +157,10 @@ const deleteMatterTask = async (params: { matterId: string; taskId: string }, ct
 const listOrganizationTasks = async (
   params: { filters?: OrgTaskListFilters },
   ctx: ServiceContext
-): Promise<SelectMatterTask[]> => {
+): Promise<OffsetPaginatedResponse<SelectMatterTask>> => {
   ForbiddenError.from(ctx.ability).throwUnlessCan('read', 'Matter');
-  return matterTasksQueries.listTasksByOrganization(ctx.organizationId, params.filters);
+  const { data, total, page, limit } = await matterTasksQueries.listTasksByOrganization(ctx.organizationId, params.filters);
+  return { data, pagination: { page, limit, total } };
 };
 
 export const matterTasksService = {

--- a/src/modules/matters/services/matter-tasks.service.ts
+++ b/src/modules/matters/services/matter-tasks.service.ts
@@ -4,7 +4,7 @@ import { matterTasksQueries } from '@/modules/matters/database/queries/matter-ta
 import type { SelectMatterTask } from '@/modules/matters/database/schema/matter-tasks.schema';
 import { matterActivityService } from '@/modules/matters/services/matter-activity.service';
 import { mattersService } from '@/modules/matters/services/matters.service';
-import type { MatterTaskListFilters } from '@/modules/matters/types/matter-filters.types';
+import type { MatterTaskListFilters, OrgTaskListFilters } from '@/modules/matters/types/matter-filters.types';
 import type { CreateMatterTaskRequest, UpdateMatterTaskRequest } from '@/modules/matters/types/matter.types';
 import type { ServiceContext } from '@/shared/types/service-context';
 
@@ -153,9 +153,18 @@ const deleteMatterTask = async (params: { matterId: string; taskId: string }, ct
   );
 };
 
+const listOrganizationTasks = async (
+  params: { filters?: OrgTaskListFilters },
+  ctx: ServiceContext
+): Promise<SelectMatterTask[]> => {
+  ForbiddenError.from(ctx.ability).throwUnlessCan('read', 'Matter');
+  return matterTasksQueries.listTasksByOrganization(ctx.organizationId, params.filters);
+};
+
 export const matterTasksService = {
   createMatterTask,
   listMatterTasks,
+  listOrganizationTasks,
   updateMatterTask,
   deleteMatterTask,
 };

--- a/src/modules/matters/services/matters.service.ts
+++ b/src/modules/matters/services/matters.service.ts
@@ -161,6 +161,8 @@ const listMatters = async (
     practiceServiceId: filters.practice_service_id,
     clientId: filters.client_id,
     assigneeId: filters.assignee_id,
+    responsibleAttorneyId: filters.responsible_attorney_id,
+    originatingAttorneyId: filters.originating_attorney_id,
     search: filters.search,
     page: filters.page,
     limit: filters.limit,
@@ -342,6 +344,24 @@ const getMatterCounts = async (ctx: ServiceContext): Promise<Record<string, numb
   }, {});
 };
 
+/**
+ * Get matters summary grouped by originating attorney.
+ */
+const getMattersSummaryByOriginatingAttorney = async (
+  _params: Record<string, never>,
+  ctx: ServiceContext
+): Promise<
+  {
+    originating_attorney_id: string | null;
+    total_matters: number;
+    active_matters: number;
+    closed_matters: number;
+  }[]
+> => {
+  ForbiddenError.from(ctx.ability).throwUnlessCan('read', 'Matter');
+  return mattersQueries.getMattersSummaryByOriginatingAttorney(ctx.organizationId);
+};
+
 const getMatterUnbilled = async (matterId: string, ctx: ServiceContext): Promise<UnbilledMatterData> => {
   await verifyMatterAccess(matterId, ctx);
 
@@ -403,5 +423,6 @@ export const mattersService = {
   updateMatter,
   deleteMatter,
   getMatterCounts,
+  getMattersSummaryByOriginatingAttorney,
   getMatterUnbilled,
 };

--- a/src/modules/matters/services/matters.service.ts
+++ b/src/modules/matters/services/matters.service.ts
@@ -11,10 +11,10 @@ import { matterMilestonesQueries } from '@/modules/matters/database/queries/matt
 import { mattersQueries } from '@/modules/matters/database/queries/matters.queries';
 import { matters } from '@/modules/matters/database/schema/matters.schema';
 import { matterActivityService } from '@/modules/matters/services/matter-activity.service';
+import type { MatterListFilters } from '@/modules/matters/types/matter-filters.types';
 import type {
   CreateMatterRequest,
   UpdateMatterRequest,
-  ListMattersQuery,
   MatterRecord,
   UnbilledMatterData,
 } from '@/modules/matters/types/matter.types';
@@ -151,22 +151,11 @@ const getMatterById = async (matterId: string, ctx: ServiceContext): Promise<Mat
  * List matters
  */
 const listMatters = async (
-  filters: ListMattersQuery,
+  filters: MatterListFilters,
   ctx: ServiceContext
 ): Promise<{ matters: MatterRecord[]; total: number }> => {
   ForbiddenError.from(ctx.ability).throwUnlessCan('read', 'Matter');
-
-  return mattersQueries.listMattersByOrganization(ctx.organizationId, {
-    status: filters.status,
-    practiceServiceId: filters.practice_service_id,
-    clientId: filters.client_id,
-    assigneeId: filters.assignee_id,
-    responsibleAttorneyId: filters.responsible_attorney_id,
-    originatingAttorneyId: filters.originating_attorney_id,
-    search: filters.search,
-    page: filters.page,
-    limit: filters.limit,
-  });
+  return mattersQueries.listMattersByOrganization(ctx.organizationId, filters);
 };
 
 /**

--- a/src/modules/matters/types/matter-filters.types.ts
+++ b/src/modules/matters/types/matter-filters.types.ts
@@ -10,6 +10,8 @@ export interface MatterListFilters {
   clientId?: string;
   matterId?: string;
   assigneeId?: string;
+  responsibleAttorneyId?: string;
+  originatingAttorneyId?: string;
   search?: string;
   page?: number;
   limit?: number;
@@ -23,6 +25,7 @@ export interface MatterNoteListFilters {
 /** Filters for listMatterTimeEntries */
 export interface MatterTimeEntryListFilters {
   billable?: boolean;
+  invoiced?: boolean;
   startDate?: Date;
   endDate?: Date;
   entryId?: string;
@@ -48,6 +51,13 @@ export interface MatterTaskListFilters {
   status?: 'pending' | 'in_progress' | 'complete' | 'blocked';
   priority?: 'low' | 'normal' | 'high' | 'urgent';
   stage?: string;
+}
+
+/** Filters for listTasksByOrganization (org-wide tasks) */
+export interface OrgTaskListFilters {
+  assigneeId?: string;
+  status?: 'pending' | 'in_progress' | 'complete' | 'blocked';
+  dueBefore?: string;
 }
 
 /** Filters for getMatterActivity */

--- a/src/modules/matters/types/matter-filters.types.ts
+++ b/src/modules/matters/types/matter-filters.types.ts
@@ -58,6 +58,8 @@ export interface OrgTaskListFilters {
   assigneeId?: string;
   status?: 'pending' | 'in_progress' | 'complete' | 'blocked';
   dueBefore?: string;
+  page?: number;
+  limit?: number;
 }
 
 /** Filters for getMatterActivity */

--- a/src/modules/matters/validations/matter-time-entries.validation.ts
+++ b/src/modules/matters/validations/matter-time-entries.validation.ts
@@ -29,6 +29,7 @@ const matterTimeEntryIdParamSchema = z.object({
 const listTimeEntriesQuerySchema = z.object({
   entry_id: uuidValidator.optional(),
   billable: z.coerce.boolean().optional(),
+  invoiced: z.coerce.boolean().optional(),
   start_date: z.coerce.date().optional(),
   end_date: z.coerce.date().optional(),
 });

--- a/src/modules/matters/validations/matters.validation.ts
+++ b/src/modules/matters/validations/matters.validation.ts
@@ -136,6 +136,8 @@ const listMattersQuerySchema = z.object({
   practice_service_id: uuidValidator.optional(),
   client_id: uuidValidator.optional(),
   assignee_id: uuidValidator.optional(),
+  responsible_attorney_id: uuidValidator.optional(),
+  originating_attorney_id: uuidValidator.optional(),
   page: z.coerce.number().int().min(1).default(1),
   limit: z.coerce.number().int().min(1).max(100).default(20),
   search: z.string().optional(),

--- a/src/modules/trust/database/queries/trust-transactions.queries.ts
+++ b/src/modules/trust/database/queries/trust-transactions.queries.ts
@@ -106,6 +106,26 @@ const getLatestBalanceByClient = async (
 };
 
 /**
+ * Get the latest balance_after per client across the entire organization.
+ * Returns one row per client with their most recent trust_transactions row.
+ */
+const getLatestBalancePerClient = async (
+  organizationId: string
+): Promise<{ client_id: string; balance: number; as_of_date: Date }[]> => {
+  const rows = await db
+    .selectDistinctOn([trustTransactions.client_id], {
+      client_id: trustTransactions.client_id,
+      balance: trustTransactions.balance_after,
+      as_of_date: trustTransactions.created_at,
+    })
+    .from(trustTransactions)
+    .where(eq(trustTransactions.organization_id, organizationId))
+    .orderBy(trustTransactions.client_id, desc(trustTransactions.created_at));
+
+  return rows.map((r) => ({ client_id: r.client_id, balance: Number(r.balance), as_of_date: r.as_of_date }));
+};
+
+/**
  * Get the latest balance_after for a specific client/matter and lock the row
  */
 const getLatestBalanceForMatter = async (
@@ -144,5 +164,6 @@ export const trustTransactionsRepository = {
   listByClient,
   listByOrg,
   getLatestBalanceByClient,
+  getLatestBalancePerClient,
   getLatestBalanceForMatter,
 };

--- a/src/modules/trust/handlers.ts
+++ b/src/modules/trust/handlers.ts
@@ -9,6 +9,7 @@ const {
   getTrustReportRoute,
   createDepositRoute,
   createWithdrawalRoute,
+  getTrustClientBalancesRoute,
 } = trustRoutes;
 
 const createDepositHandler: AppRouteHandler<typeof createDepositRoute> = async (c) => {
@@ -74,10 +75,17 @@ const getTrustReportHandler: AppRouteHandler<typeof getTrustReportRoute> = async
   return c.json(report, 200);
 };
 
+const getTrustClientBalancesHandler: AppRouteHandler<typeof getTrustClientBalancesRoute> = async (c) => {
+  const ctx = getServiceContext(c);
+  const balances = await trustService.getClientBalances({}, ctx);
+  return c.json(balances, 200);
+};
+
 export const handlers = {
   createDepositHandler,
   createWithdrawalHandler,
   getTrustTransactionsHandler,
   getTrustBalanceHandler,
   getTrustReportHandler,
+  getTrustClientBalancesHandler,
 };

--- a/src/modules/trust/http.ts
+++ b/src/modules/trust/http.ts
@@ -12,6 +12,7 @@ app.openapi(routes.createWithdrawalRoute, handlers.createWithdrawalHandler);
 app.openapi(routes.getTrustTransactionsRoute, handlers.getTrustTransactionsHandler);
 app.openapi(routes.getTrustBalanceRoute, handlers.getTrustBalanceHandler);
 app.openapi(routes.getTrustReportRoute, handlers.getTrustReportHandler);
+app.openapi(routes.getTrustClientBalancesRoute, handlers.getTrustClientBalancesHandler);
 
 registerOpenApiRoutes(app, { ...routes });
 

--- a/src/modules/trust/routes.ts
+++ b/src/modules/trust/routes.ts
@@ -71,7 +71,8 @@ const getTrustTransactionsRoute = routeBuilder.build({
   path: '/{practice_id}/transactions',
   tags: ['Trust'],
   summary: 'List trust transactions',
-  description: 'List trust transactions for a client, optionally filtered by matter.',
+  description:
+    'List trust transactions for the organization, ordered by created_at DESC. When client_id is omitted, returns org-wide transactions; when provided, scopes to that client. Optionally filterable by matter_id and date range.',
   request: {
     params: practiceIdParamSchema,
     query: z.object({
@@ -135,10 +136,37 @@ const getTrustReportRoute = routeBuilder.build({
   },
 });
 
+const clientBalanceSchema = z
+  .object({
+    client_id: z.uuid(),
+    balance: z.number().describe('Balance in cents'),
+    as_of_date: z.iso.datetime({ offset: true }),
+  })
+  .openapi('TrustClientBalance', { description: 'Latest trust balance for a client' });
+
+const getTrustClientBalancesRoute = routeBuilder.build({
+  method: 'get',
+  path: '/{practice_id}/client-balances',
+  tags: ['Trust'],
+  summary: 'List latest trust balance per client',
+  description:
+    'Returns the latest trust balance_after per client across the organization, one row per client with the timestamp of the underlying transaction.',
+  request: {
+    params: practiceIdParamSchema,
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: z.array(clientBalanceSchema) } },
+      description: 'Latest trust balance per client retrieved',
+    },
+  },
+});
+
 export const trustRoutes = {
   createDepositRoute,
   createWithdrawalRoute,
   getTrustTransactionsRoute,
   getTrustBalanceRoute,
   getTrustReportRoute,
+  getTrustClientBalancesRoute,
 };

--- a/src/modules/trust/services/trust.service.ts
+++ b/src/modules/trust/services/trust.service.ts
@@ -192,6 +192,17 @@ const getReport = async (params: GetReportParams, ctx: ServiceContext): Promise<
   return trustTransactionsRepository.listByOrg(params);
 };
 
+/**
+ * Get the latest trust balance per client across the organization.
+ */
+const getClientBalances = async (
+  _params: Record<string, never>,
+  ctx: ServiceContext
+): Promise<{ client_id: string; balance: number; as_of_date: Date }[]> => {
+  ForbiddenError.from(ctx.ability).throwUnlessCan('read', 'Trust');
+  return trustTransactionsRepository.getLatestBalancePerClient(ctx.organizationId);
+};
+
 interface ManualTrustData {
   matter_id: string;
   client_id: string;
@@ -296,4 +307,5 @@ export const trustService = {
   getBalance,
   getBalanceWithTx,
   getReport,
+  getClientBalances,
 };

--- a/src/shared/auth/hooks/databaseHooks.ts
+++ b/src/shared/auth/hooks/databaseHooks.ts
@@ -1,135 +1,33 @@
 /**
  * Database Hooks for Better Auth
  *
- * Handles database-level events (user creation, session management)
+ * Handles database-level events (user creation, session management).
+ *
+ * Customization scope (issue #571 auth-routing cleanup, 2026-05-15):
+ *   This file used to:
+ *     1. Auto-add new users as `member.role='client'` on signup when their
+ *        email matched a "succeeded" intake — bypassing better-auth's
+ *        documented invite + accept flow.
+ *     2. Auto-set `session.activeOrganizationId` from the user's prior
+ *        session or first membership — bypassing better-auth's documented
+ *        `authClient.organization.setActive()` flow.
+ *
+ *   Both auto-behaviors produced inconsistent state where a user's
+ *   `user.primary_workspace='practice'` could coexist with
+ *   `member.role='client'` in the auto-picked active org, and the worker
+ *   plus frontend then routed the user to /client/ workspaces.
+ *
+ *   Per the documented better-auth flow:
+ *     - Clients only become members by accepting an invitation
+ *       (POST /organization/accept-invitation).
+ *     - The active organization is set by the client via
+ *       authClient.organization.setActive(orgId).
  */
 
-import { getLogger } from '@logtape/logtape';
-import { eq, and, sql, desc } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
-import { practiceClientIntakes } from '@/modules/practice-client-intakes/database/schema/practice-client-intakes.schema';
 import * as schema from '@/schema';
-import { AuthUserSignedUp, PracticeMemberJoined } from '@/shared/events/definitions';
-
-const logger = getLogger(['auth', 'database-hooks']);
-
-const INTAKE_STATUS_SUCCEEDED = 'succeeded';
-const ROLE_CLIENT = 'client';
-
-interface CheckPendingIntakesParams {
-  db: NodePgDatabase<typeof schema>;
-  userId: string;
-  email: string;
-}
-
-interface GetActiveOrgParams {
-  db: NodePgDatabase<typeof schema>;
-  userId: string;
-  lastActiveOrgId: string | null;
-}
-
-/**
- * Check for pending intakes by email and add user to organization.
- * This handles the case where anonymous session was lost but user authenticates
- * with the same email they used during intake.
- */
-const checkPendingIntakesByEmail = async ({ db, userId, email }: CheckPendingIntakesParams): Promise<void> => {
-  // Find succeeded intakes matching this email that haven't been processed
-  const pendingIntakes = await db
-    .select()
-    .from(practiceClientIntakes)
-    .where(
-      and(
-        eq(practiceClientIntakes.status, INTAKE_STATUS_SUCCEEDED),
-        eq(sql<string>`lower(${practiceClientIntakes.metadata} ->> 'email')`, email.toLowerCase())
-      )
-    );
-
-  for (const intake of pendingIntakes) {
-    try {
-      // Add user to organization as client (Atomic insert using unique constraint)
-      const [newMember] = await db
-        .insert(schema.members)
-        .values({
-          organizationId: intake.organization_id,
-          userId: userId,
-          role: ROLE_CLIENT,
-          createdAt: new Date(),
-        })
-        .onConflictDoNothing()
-        .returning();
-
-      if (newMember) {
-        // Mark user as needing onboarding
-        await db.update(schema.users).set({ onboardingComplete: false }).where(eq(schema.users.id, userId));
-
-        logger.info('Added user {userId} to organization {orgId} from pending intake {intakeId} (email match)', {
-          userId,
-          orgId: intake.organization_id,
-          intakeId: intake.id,
-        });
-
-        // Dispatch event with error handling
-        try {
-          await PracticeMemberJoined.dispatch(
-            {
-              member_id: newMember.id,
-              intake_id: intake.id,
-            },
-            {
-              actorId: userId,
-              organizationId: intake.organization_id,
-            }
-          );
-        } catch (dispatchError) {
-          logger.error(
-            'Failed to dispatch PracticeMemberJoined event for user {userId} and intake {intakeId}: {error}',
-            {
-              userId,
-              intakeId: intake.id,
-              error: dispatchError,
-            }
-          );
-        }
-      }
-    } catch (error) {
-      logger.error('Failed to process pending intake {intakeId} for user {userId}: {error}', {
-        intakeId: intake.id,
-        userId,
-        error,
-      });
-    }
-  }
-};
-
-/**
- * Get active organization ID for a user
- * Tries to preserve last active organization, falls back to first organization
- */
-const getActiveOrganizationId = async ({ db, userId, lastActiveOrgId }: GetActiveOrgParams): Promise<string | null> => {
-  // First, try to use the last active organization if it's still valid
-  if (lastActiveOrgId) {
-    const orgValidation = await db
-      .select({ id: schema.organizations.id })
-      .from(schema.organizations)
-      .innerJoin(schema.members, eq(schema.organizations.id, schema.members.organizationId))
-      .where(and(eq(schema.organizations.id, lastActiveOrgId), eq(schema.members.userId, userId)))
-      .limit(1);
-
-    if (orgValidation.length > 0) {
-      return lastActiveOrgId;
-    }
-  }
-
-  // Fall back to first organization user belongs to
-  const userOrgs = await db
-    .select({ organizationId: schema.members.organizationId })
-    .from(schema.members)
-    .where(eq(schema.members.userId, userId))
-    .limit(1);
-
-  return userOrgs.length > 0 ? userOrgs[0].organizationId : null;
-};
+import { AuthUserSignedUp } from '@/shared/events/definitions';
 
 type UserData = Record<string, unknown> & {
   id: string;
@@ -143,9 +41,6 @@ type SessionData = Record<string, unknown> & {
   id: string;
 };
 
-/**
- * Create database hooks configuration
- */
 export const createDatabaseHooks = (
   db: NodePgDatabase<typeof schema>
 ): {
@@ -156,8 +51,7 @@ export const createDatabaseHooks = (
   };
   session: {
     create: {
-      before: (sessionData: SessionData) => Promise<{ data: SessionData & { activeOrganizationId: string | null } }>;
-      after: (session: SessionData) => Promise<void>;
+      before: (sessionData: SessionData) => Promise<{ data: SessionData }>;
     };
   };
 } => ({
@@ -180,57 +74,13 @@ export const createDatabaseHooks = (
   },
   session: {
     create: {
-      before: async (
-        sessionData: SessionData
-      ): Promise<{ data: SessionData & { activeOrganizationId: string | null } }> => {
-        // Get last active organization from previous session
-        const lastActiveSession = await db
-          .select({
-            activeOrganizationId: schema.sessions.activeOrganizationId,
-          })
-          .from(schema.sessions)
-          .where(eq(schema.sessions.userId, sessionData.userId))
-          .orderBy(desc(schema.sessions.createdAt))
-          .limit(1);
-
-        // Delete all existing sessions for this user (single session per user)
+      // Enforce one session per user (the platform invariant we still want).
+      // Do NOT auto-fill activeOrganizationId here — the client app is
+      // responsible for calling authClient.organization.setActive() after
+      // sign-in, per the better-auth organization plugin docs.
+      before: async (sessionData: SessionData): Promise<{ data: SessionData }> => {
         await db.delete(schema.sessions).where(eq(schema.sessions.userId, sessionData.userId));
-
-        // Determine active organization
-        let activeOrganizationId: string | null = null;
-        try {
-          activeOrganizationId = await getActiveOrganizationId({
-            db,
-            userId: sessionData.userId,
-            lastActiveOrgId: lastActiveSession.length > 0 ? lastActiveSession[0].activeOrganizationId : null,
-          });
-        } catch (error) {
-          logger.warn('Failed to set active organization for user {userId}', { userId: sessionData.userId, error });
-        }
-
-        return {
-          data: { ...sessionData, activeOrganizationId },
-        };
-      },
-      after: async (session: SessionData): Promise<void> => {
-        // Check for pending intakes by email (handles lost anonymous session case)
-        try {
-          const [user] = await db
-            .select({ email: schema.users.email, isAnonymous: schema.users.isAnonymous })
-            .from(schema.users)
-            .where(eq(schema.users.id, session.userId))
-            .limit(1);
-
-          // Only check for non-anonymous users (anonymous users are handled by onLinkAccount)
-          if (user && !user.isAnonymous) {
-            await checkPendingIntakesByEmail({ db, userId: session.userId, email: user.email });
-          }
-        } catch (error) {
-          logger.error('Failed to check pending intakes for session {sessionId}: {error}', {
-            sessionId: session.id,
-            error,
-          });
-        }
+        return { data: sessionData };
       },
     },
   },

--- a/src/shared/auth/hooks/databaseHooks.ts
+++ b/src/shared/auth/hooks/databaseHooks.ts
@@ -3,31 +3,93 @@
  *
  * Handles database-level events (user creation, session management).
  *
- * Customization scope (issue #571 auth-routing cleanup, 2026-05-15):
- *   This file used to:
- *     1. Auto-add new users as `member.role='client'` on signup when their
- *        email matched a "succeeded" intake — bypassing better-auth's
- *        documented invite + accept flow.
- *     2. Auto-set `session.activeOrganizationId` from the user's prior
- *        session or first membership — bypassing better-auth's documented
- *        `authClient.organization.setActive()` flow.
- *
- *   Both auto-behaviors produced inconsistent state where a user's
- *   `user.primary_workspace='practice'` could coexist with
- *   `member.role='client'` in the auto-picked active org, and the worker
- *   plus frontend then routed the user to /client/ workspaces.
- *
- *   Per the documented better-auth flow:
- *     - Clients only become members by accepting an invitation
- *       (POST /organization/accept-invitation).
- *     - The active organization is set by the client via
- *       authClient.organization.setActive(orgId).
+ * activeOrganizationId is intentionally NOT auto-set on session create.
+ * The client app calls authClient.organization.setActive() after sign-in
+ * per the better-auth organization plugin docs. Auto-setting it caused
+ * inconsistent routing when primary_workspace didn't match the auto-picked org.
  */
 
-import { eq } from 'drizzle-orm';
+import { getLogger } from '@logtape/logtape';
+import { and, eq, sql } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { practiceClientIntakes } from '@/modules/practice-client-intakes/database/schema/practice-client-intakes.schema';
 import * as schema from '@/schema';
-import { AuthUserSignedUp } from '@/shared/events/definitions';
+import { AuthUserSignedUp, PracticeMemberJoined } from '@/shared/events/definitions';
+
+const logger = getLogger(['auth', 'database-hooks']);
+
+const INTAKE_STATUS_SUCCEEDED = 'succeeded';
+const ROLE_CLIENT = 'client';
+
+interface CheckPendingIntakesParams {
+  db: NodePgDatabase<typeof schema>;
+  userId: string;
+  email: string;
+}
+
+/**
+ * When a client completes an intake anonymously then later authenticates with
+ * the same email, enroll them in the org automatically. Sets primary_workspace
+ * to 'client' so routing state is consistent with member.role='client'.
+ */
+const checkPendingIntakesByEmail = async ({ db, userId, email }: CheckPendingIntakesParams): Promise<void> => {
+  const pendingIntakes = await db
+    .select()
+    .from(practiceClientIntakes)
+    .where(
+      and(
+        eq(practiceClientIntakes.status, INTAKE_STATUS_SUCCEEDED),
+        eq(sql<string>`lower(${practiceClientIntakes.metadata} ->> 'email')`, email.toLowerCase())
+      )
+    );
+
+  for (const intake of pendingIntakes) {
+    try {
+      const [newMember] = await db
+        .insert(schema.members)
+        .values({
+          organizationId: intake.organization_id,
+          userId,
+          role: ROLE_CLIENT,
+          createdAt: new Date(),
+        })
+        .onConflictDoNothing()
+        .returning();
+
+      if (newMember) {
+        await db
+          .update(schema.users)
+          .set({ onboardingComplete: false, primaryWorkspace: ROLE_CLIENT })
+          .where(eq(schema.users.id, userId));
+
+        logger.info('Added user {userId} to organization {orgId} from pending intake {intakeId} (email match)', {
+          userId,
+          orgId: intake.organization_id,
+          intakeId: intake.id,
+        });
+
+        try {
+          await PracticeMemberJoined.dispatch(
+            { member_id: newMember.id, intake_id: intake.id },
+            { actorId: userId, organizationId: intake.organization_id }
+          );
+        } catch (dispatchError) {
+          logger.error('Failed to dispatch PracticeMemberJoined for user {userId} intake {intakeId}: {error}', {
+            userId,
+            intakeId: intake.id,
+            error: dispatchError,
+          });
+        }
+      }
+    } catch (error) {
+      logger.error('Failed to process pending intake {intakeId} for user {userId}: {error}', {
+        intakeId: intake.id,
+        userId,
+        error,
+      });
+    }
+  }
+};
 
 type UserData = Record<string, unknown> & {
   id: string;
@@ -52,6 +114,7 @@ export const createDatabaseHooks = (
   session: {
     create: {
       before: (sessionData: SessionData) => Promise<{ data: SessionData }>;
+      after: (session: SessionData) => Promise<void>;
     };
   };
 } => ({
@@ -74,13 +137,29 @@ export const createDatabaseHooks = (
   },
   session: {
     create: {
-      // Enforce one session per user (the platform invariant we still want).
-      // Do NOT auto-fill activeOrganizationId here — the client app is
-      // responsible for calling authClient.organization.setActive() after
-      // sign-in, per the better-auth organization plugin docs.
+      // Enforce one session per user. Do NOT auto-fill activeOrganizationId —
+      // client app calls authClient.organization.setActive() after sign-in.
       before: async (sessionData: SessionData): Promise<{ data: SessionData }> => {
         await db.delete(schema.sessions).where(eq(schema.sessions.userId, sessionData.userId));
         return { data: sessionData };
+      },
+      after: async (session: SessionData): Promise<void> => {
+        try {
+          const [user] = await db
+            .select({ email: schema.users.email, isAnonymous: schema.users.isAnonymous })
+            .from(schema.users)
+            .where(eq(schema.users.id, session.userId))
+            .limit(1);
+
+          if (user && !user.isAnonymous) {
+            await checkPendingIntakesByEmail({ db, userId: session.userId, email: user.email });
+          }
+        } catch (error) {
+          logger.error('Failed to check pending intakes for session {sessionId}: {error}', {
+            sessionId: session.id,
+            error,
+          });
+        }
       },
     },
   },

--- a/test/modules/matters/matters-reports.test.ts
+++ b/test/modules/matters/matters-reports.test.ts
@@ -1,0 +1,389 @@
+import { randomUUID } from 'node:crypto';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+
+import { authHelpers } from '@/test/helpers/auth';
+import { getTestDb } from '@/test/helpers/db';
+import { createAuthenticatedRequest, createRequest } from '@/test/helpers/request';
+import type { TestOrganization } from '@/test/types/shared';
+import { toTypedResponse } from '@/test/helpers/response';
+import mattersApp from '@/modules/matters/http';
+import { matters } from '@/modules/matters/database/schema/matters.schema';
+import { matterTasks } from '@/modules/matters/database/schema/matter-tasks.schema';
+import { matterTimeEntries } from '@/modules/matters/database/schema/matter-time-entries.schema';
+import { requireAuth } from '@/shared/middleware/requireAuth';
+import { requireOrgMembership } from '@/shared/middleware/requireOrgMembership';
+import type { SelectMatter } from '@/modules/matters/database/schema/matters.schema';
+import type { SelectMatterTask } from '@/modules/matters/database/schema/matter-tasks.schema';
+import type { SelectMatterTimeEntry } from '@/modules/matters/database/schema/matter-time-entries.schema';
+
+const { createTestContext, createTestUser, addUserToOrganization } = authHelpers;
+
+const orgProtectedApp = new Hono();
+orgProtectedApp.use('/api/*', requireAuth());
+orgProtectedApp.use('/api/*', requireOrgMembership());
+orgProtectedApp.route('/api/matters', mattersApp);
+
+const orgProtectedRequest = createRequest(orgProtectedApp.fetch);
+
+const authedRequest = (sessionToken: string): ReturnType<typeof createAuthenticatedRequest> =>
+  createAuthenticatedRequest(orgProtectedApp.fetch, sessionToken);
+
+interface InsertMatterParams {
+  orgId: string;
+  title: string;
+  status?: SelectMatter['status'];
+  responsibleAttorneyId?: string | null;
+  originatingAttorneyId?: string | null;
+}
+
+const insertMatter = async (params: InsertMatterParams): Promise<SelectMatter> => {
+  const db = getTestDb();
+  const [row] = await db
+    .insert(matters)
+    .values({
+      organization_id: params.orgId,
+      title: params.title,
+      billing_type: 'hourly',
+      attorney_hourly_rate: 10000,
+      status: params.status ?? 'active',
+      responsible_attorney_id: params.responsibleAttorneyId ?? null,
+      originating_attorney_id: params.originatingAttorneyId ?? null,
+    })
+    .returning();
+  return row;
+};
+
+interface InsertTimeEntryParams {
+  matterId: string;
+  userId: string;
+  billable: boolean;
+  invoiceId?: string | null;
+  startTime?: Date;
+  endTime?: Date;
+}
+
+const insertTimeEntry = async (params: InsertTimeEntryParams): Promise<SelectMatterTimeEntry> => {
+  const db = getTestDb();
+  const start = params.startTime ?? new Date('2026-04-01T09:00:00Z');
+  const end = params.endTime ?? new Date('2026-04-01T10:00:00Z');
+  const [row] = await db
+    .insert(matterTimeEntries)
+    .values({
+      matter_id: params.matterId,
+      user_id: params.userId,
+      start_time: start,
+      end_time: end,
+      duration: Math.floor((end.getTime() - start.getTime()) / 1000),
+      billable: params.billable,
+      invoice_id: params.invoiceId ?? null,
+      invoiced_at: params.invoiceId ? new Date() : null,
+    })
+    .returning();
+  return row;
+};
+
+interface InsertTaskParams {
+  matterId: string;
+  name: string;
+  assigneeId?: string | null;
+  dueDate?: string | null;
+  status?: 'pending' | 'in_progress' | 'complete' | 'blocked';
+}
+
+const insertTask = async (params: InsertTaskParams): Promise<SelectMatterTask> => {
+  const db = getTestDb();
+  const [row] = await db
+    .insert(matterTasks)
+    .values({
+      matter_id: params.matterId,
+      name: params.name,
+      stage: 'discovery',
+      assignee_id: params.assigneeId ?? null,
+      due_date: params.dueDate ?? null,
+      status: params.status ?? 'pending',
+    })
+    .returning();
+  return row;
+};
+
+interface MattersListResponseBody {
+  matters: SelectMatter[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+interface SummaryRow {
+  originating_attorney_id: string | null;
+  total_matters: number;
+  active_matters: number;
+  closed_matters: number;
+}
+
+describe('Matters reports endpoints', () => {
+  let sessionToken = '';
+  let org: TestOrganization = { id: '', name: '', slug: '' };
+  let ownerId = '';
+  let attorneyAId = '';
+  let attorneyBId = '';
+
+  let matterAttorneyA: SelectMatter;
+  let matterAttorneyB: SelectMatter;
+  let matterOriginatingAClosed: SelectMatter;
+  let matterOriginatingANoResponsible: SelectMatter;
+
+  beforeAll(async () => {
+    const ctx = await createTestContext('owner');
+    org = ctx.org;
+    sessionToken = ctx.sessionToken;
+    const session = ctx.session as { user: { id: string } } | null;
+    ownerId = session!.user.id;
+
+    // Create two other users to use as attorneys and add them to the org as members
+    const attorneyA = await createTestUser({ email: `attorney-a-${randomUUID().slice(0, 8)}@test.example`, name: 'Attorney A' });
+    const attorneyB = await createTestUser({ email: `attorney-b-${randomUUID().slice(0, 8)}@test.example`, name: 'Attorney B' });
+    await addUserToOrganization(attorneyA.id, org.id, 'admin');
+    await addUserToOrganization(attorneyB.id, org.id, 'admin');
+    attorneyAId = attorneyA.id;
+    attorneyBId = attorneyB.id;
+
+    // Matters
+    matterAttorneyA = await insertMatter({
+      orgId: org.id,
+      title: 'Matter — Resp A / Orig A',
+      status: 'active',
+      responsibleAttorneyId: attorneyAId,
+      originatingAttorneyId: attorneyAId,
+    });
+    matterAttorneyB = await insertMatter({
+      orgId: org.id,
+      title: 'Matter — Resp B / Orig B',
+      status: 'active',
+      responsibleAttorneyId: attorneyBId,
+      originatingAttorneyId: attorneyBId,
+    });
+    matterOriginatingAClosed = await insertMatter({
+      orgId: org.id,
+      title: 'Matter — Orig A closed',
+      status: 'closed',
+      responsibleAttorneyId: null,
+      originatingAttorneyId: attorneyAId,
+    });
+    matterOriginatingANoResponsible = await insertMatter({
+      orgId: org.id,
+      title: 'Matter — Orig A active no responsible',
+      status: 'active',
+      responsibleAttorneyId: null,
+      originatingAttorneyId: attorneyAId,
+    });
+
+    // Time entries for matterAttorneyA
+    await insertTimeEntry({ matterId: matterAttorneyA.id, userId: ownerId, billable: true, invoiceId: null });
+    await insertTimeEntry({
+      matterId: matterAttorneyA.id,
+      userId: ownerId,
+      billable: false,
+      invoiceId: null,
+      startTime: new Date('2026-04-02T09:00:00Z'),
+      endTime: new Date('2026-04-02T10:00:00Z'),
+    });
+    // Tasks
+    await insertTask({
+      matterId: matterAttorneyA.id,
+      name: 'Task — assignee A, due 2026-06-01, pending',
+      assigneeId: attorneyAId,
+      dueDate: '2026-06-01',
+      status: 'pending',
+    });
+    await insertTask({
+      matterId: matterAttorneyA.id,
+      name: 'Task — assignee B, due 2026-12-01, in_progress',
+      assigneeId: attorneyBId,
+      dueDate: '2026-12-01',
+      status: 'in_progress',
+    });
+    await insertTask({
+      matterId: matterAttorneyB.id,
+      name: 'Task — no due date, assignee A',
+      assigneeId: attorneyAId,
+      dueDate: null,
+      status: 'pending',
+    });
+  });
+
+  // ==================== Time entries — invoiced filter ====================
+
+  it('GET time-entries with invoiced=false returns only entries where invoice_id IS NULL', async () => {
+    const res = await toTypedResponse<SelectMatterTimeEntry[]>(
+      authedRequest(sessionToken).get(`/api/matters/${org.id}/${matterAttorneyA.id}/time-entries?invoiced=false`)
+    );
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThanOrEqual(1);
+    expect(res.body.every((e) => e.invoice_id === null)).toBe(true);
+  });
+
+  it('GET time-entries with invoiced=true returns 0 entries when none are invoiced', async () => {
+    // Our test data has no invoiced entries (no invoice rows created), so this should be empty.
+    const res = await toTypedResponse<SelectMatterTimeEntry[]>(
+      authedRequest(sessionToken).get(`/api/matters/${org.id}/${matterAttorneyA.id}/time-entries?invoiced=true`)
+    );
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBe(0);
+  });
+
+  it('GET time-entries with billable=true filters correctly (regression — already exists)', async () => {
+    const res = await toTypedResponse<SelectMatterTimeEntry[]>(
+      authedRequest(sessionToken).get(`/api/matters/${org.id}/${matterAttorneyA.id}/time-entries?billable=true`)
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.every((e) => e.billable === true)).toBe(true);
+  });
+
+  // ==================== Matters list — attorney filters ====================
+
+  it('GET /{practice_id} with responsible_attorney_id=<uuid> filters correctly', async () => {
+    const res = await toTypedResponse<MattersListResponseBody>(
+      authedRequest(sessionToken).get(`/api/matters/${org.id}?responsible_attorney_id=${attorneyAId}`)
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.matters.length).toBeGreaterThanOrEqual(1);
+    expect(res.body.matters.every((m) => m.responsible_attorney_id === attorneyAId)).toBe(true);
+    const titles = res.body.matters.map((m) => m.title);
+    expect(titles).toContain(matterAttorneyA.title);
+    expect(titles).not.toContain(matterAttorneyB.title);
+  });
+
+  it('GET /{practice_id} with originating_attorney_id=<uuid> filters correctly', async () => {
+    const res = await toTypedResponse<MattersListResponseBody>(
+      authedRequest(sessionToken).get(`/api/matters/${org.id}?originating_attorney_id=${attorneyAId}`)
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.matters.every((m) => m.originating_attorney_id === attorneyAId)).toBe(true);
+    const ids = new Set(res.body.matters.map((m) => m.id));
+    expect(ids.has(matterAttorneyA.id)).toBe(true);
+    expect(ids.has(matterOriginatingAClosed.id)).toBe(true);
+    expect(ids.has(matterOriginatingANoResponsible.id)).toBe(true);
+    expect(ids.has(matterAttorneyB.id)).toBe(false);
+  });
+
+  it('GET /{practice_id} with status filter (regression — already exists)', async () => {
+    const res = await toTypedResponse<MattersListResponseBody>(
+      authedRequest(sessionToken).get(`/api/matters/${org.id}?status=closed`)
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.matters.every((m) => m.status === 'closed')).toBe(true);
+    expect(res.body.matters.some((m) => m.id === matterOriginatingAClosed.id)).toBe(true);
+  });
+
+  // ==================== Summary by originating attorney ====================
+
+  it('GET /{practice_id}/summary/by-originating-attorney returns one group per attorney with correct counts', async () => {
+    const res = await toTypedResponse<SummaryRow[]>(
+      authedRequest(sessionToken).get(`/api/matters/${org.id}/summary/by-originating-attorney`)
+    );
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+
+    const byAttorney = new Map(res.body.map((r) => [r.originating_attorney_id, r]));
+
+    // Attorney A: 3 total (1 active, 1 closed, 1 active no responsible)
+    const a = byAttorney.get(attorneyAId);
+    expect(a).toBeDefined();
+    expect(a!.total_matters).toBe(3);
+    expect(a!.closed_matters).toBe(1);
+    expect(a!.active_matters).toBe(2);
+
+    // Attorney B: 1 total, 1 active, 0 closed
+    const b = byAttorney.get(attorneyBId);
+    expect(b).toBeDefined();
+    expect(b!.total_matters).toBe(1);
+    expect(b!.closed_matters).toBe(0);
+    expect(b!.active_matters).toBe(1);
+  });
+
+  // ==================== Org-wide tasks ====================
+
+  it('GET /{practice_id}/tasks returns org-wide tasks (no filter)', async () => {
+    const res = await toTypedResponse<SelectMatterTask[]>(
+      authedRequest(sessionToken).get(`/api/matters/${org.id}/tasks`)
+    );
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThanOrEqual(3);
+    // All returned tasks are linked to matters within the org (we cannot assert org_id directly on task)
+    // but we should see tasks from both matterAttorneyA and matterAttorneyB
+    const matterIds = new Set(res.body.map((t) => t.matter_id));
+    expect(matterIds.has(matterAttorneyA.id)).toBe(true);
+    expect(matterIds.has(matterAttorneyB.id)).toBe(true);
+  });
+
+  it('GET /{practice_id}/tasks with assignee_id filters correctly', async () => {
+    const res = await toTypedResponse<SelectMatterTask[]>(
+      authedRequest(sessionToken).get(`/api/matters/${org.id}/tasks?assignee_id=${attorneyBId}`)
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.every((t) => t.assignee_id === attorneyBId)).toBe(true);
+    expect(res.body.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('GET /{practice_id}/tasks with status filters correctly', async () => {
+    const res = await toTypedResponse<SelectMatterTask[]>(
+      authedRequest(sessionToken).get(`/api/matters/${org.id}/tasks?status=in_progress`)
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.every((t) => t.status === 'in_progress')).toBe(true);
+  });
+
+  it('GET /{practice_id}/tasks with due_before=<date> excludes tasks with NULL due_date', async () => {
+    const res = await toTypedResponse<SelectMatterTask[]>(
+      authedRequest(sessionToken).get(`/api/matters/${org.id}/tasks?due_before=2026-08-01`)
+    );
+
+    expect(res.status).toBe(200);
+    // The task due 2026-06-01 should match; the task due 2026-12-01 should not; the null-due task should not.
+    expect(res.body.every((t) => t.due_date !== null)).toBe(true);
+    expect(res.body.length).toBeGreaterThanOrEqual(1);
+    const names = res.body.map((t) => t.name);
+    expect(names).toContain('Task — assignee A, due 2026-06-01, pending');
+    expect(names).not.toContain('Task — assignee B, due 2026-12-01, in_progress');
+    expect(names).not.toContain('Task — no due date, assignee A');
+  });
+
+  it('GET /{practice_id}/tasks is NOT caught by requireMatterAccess() (literal path wins)', async () => {
+    // If this were caught by the matter sub-router, the middleware would attempt to verify
+    // a matter with id "tasks" and respond with 404. We assert it returns 200 instead.
+    const res = await authedRequest(sessionToken).get(`/api/matters/${org.id}/tasks`);
+    expect([200]).toContain(res.status);
+  });
+
+  it('GET /{practice_id}/summary/by-originating-attorney is NOT caught by requireMatterAccess() (literal path wins)', async () => {
+    const res = await authedRequest(sessionToken).get(`/api/matters/${org.id}/summary/by-originating-attorney`);
+    expect([200]).toContain(res.status);
+  });
+
+  // ==================== Auth ====================
+
+  it('GET /{practice_id}/tasks returns 401 for unauthenticated request', async () => {
+    const res = await orgProtectedRequest.get(`/api/matters/${org.id}/tasks`);
+    expect(res.status).toBe(401);
+  });
+
+  it('GET /{practice_id}/summary/by-originating-attorney returns 401 for unauthenticated request', async () => {
+    const res = await orgProtectedRequest.get(`/api/matters/${org.id}/summary/by-originating-attorney`);
+    expect(res.status).toBe(401);
+  });
+});

--- a/test/modules/trust/trust-reports.test.ts
+++ b/test/modules/trust/trust-reports.test.ts
@@ -1,0 +1,166 @@
+import { randomUUID } from 'node:crypto';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+
+import { authHelpers } from '@/test/helpers/auth';
+import { getTestDb } from '@/test/helpers/db';
+import { createAuthenticatedRequest, createRequest } from '@/test/helpers/request';
+import type { TestOrganization } from '@/test/types/shared';
+import { toTypedResponse } from '@/test/helpers/response';
+import trustApp from '@/modules/trust/http';
+import { clients } from '@/modules/clients/database/schema/clients.schema';
+import { trustTransactions } from '@/modules/trust/database/schema/trust-transactions.schema';
+import { requireAuth } from '@/shared/middleware/requireAuth';
+import { requireOrgMembership } from '@/shared/middleware/requireOrgMembership';
+import type { SelectTrustTransaction } from '@/modules/trust/database/schema/trust-transactions.schema';
+
+const { createTestContext } = authHelpers;
+
+const orgProtectedApp = new Hono();
+orgProtectedApp.use('/api/*', requireAuth());
+orgProtectedApp.use('/api/*', requireOrgMembership());
+orgProtectedApp.route('/api/trust', trustApp);
+
+const orgProtectedRequest = createRequest(orgProtectedApp.fetch);
+
+const authedRequest = (sessionToken: string): ReturnType<typeof createAuthenticatedRequest> =>
+  createAuthenticatedRequest(orgProtectedApp.fetch, sessionToken);
+
+const insertClient = async (orgId: string, name: string) => {
+  const db = getTestDb();
+  const [client] = await db
+    .insert(clients)
+    .values({
+      organization_id: orgId,
+      name,
+      email: `${name.toLowerCase().replace(/\s+/g, '-')}-${randomUUID().slice(0, 8)}@test.example`,
+      status: 'active',
+    })
+    .returning();
+  return client;
+};
+
+const insertTrustTransaction = async (params: {
+  orgId: string;
+  clientId: string;
+  amount: number;
+  balanceAfter: number;
+  createdBy: string;
+  createdAt?: Date;
+}): Promise<SelectTrustTransaction> => {
+  const db = getTestDb();
+  const [row] = await db
+    .insert(trustTransactions)
+    .values({
+      organization_id: params.orgId,
+      client_id: params.clientId,
+      transaction_type: 'deposit',
+      amount: params.amount,
+      balance_after: params.balanceAfter,
+      created_by: params.createdBy,
+      ...(params.createdAt && { created_at: params.createdAt }),
+    })
+    .returning();
+  return row;
+};
+
+describe('Trust reports endpoints', () => {
+  let sessionToken = '';
+  let org: TestOrganization = { id: '', name: '', slug: '' };
+  let session: { user: { id: string } } | null = null;
+  let clientAId = '';
+  let clientBId = '';
+
+  beforeAll(async () => {
+    const ctx = await createTestContext('owner');
+    org = ctx.org;
+    sessionToken = ctx.sessionToken;
+    session = ctx.session as { user: { id: string } } | null;
+    const userId = session!.user.id;
+
+    const clientA = await insertClient(org.id, 'Client A');
+    const clientB = await insertClient(org.id, 'Client B');
+    clientAId = clientA.id;
+    clientBId = clientB.id;
+
+    // Client A: two deposits, latest balance 1500
+    await insertTrustTransaction({
+      orgId: org.id,
+      clientId: clientAId,
+      amount: 1000,
+      balanceAfter: 1000,
+      createdBy: userId,
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+    });
+    await insertTrustTransaction({
+      orgId: org.id,
+      clientId: clientAId,
+      amount: 500,
+      balanceAfter: 1500,
+      createdBy: userId,
+      createdAt: new Date('2026-02-01T00:00:00Z'),
+    });
+
+    // Client B: one deposit, latest balance 2500
+    await insertTrustTransaction({
+      orgId: org.id,
+      clientId: clientBId,
+      amount: 2500,
+      balanceAfter: 2500,
+      createdBy: userId,
+      createdAt: new Date('2026-03-01T00:00:00Z'),
+    });
+  });
+
+  it('GET /{practice_id}/transactions returns org-wide transactions without client_id, ordered by created_at DESC', async () => {
+    const res = await toTypedResponse<SelectTrustTransaction[]>(
+      authedRequest(sessionToken).get(`/api/trust/${org.id}/transactions`)
+    );
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBe(3);
+
+    // All belong to the org
+    expect(res.body.every((t) => t.organization_id === org.id)).toBe(true);
+
+    // Includes both clients
+    const clientIds = new Set(res.body.map((t) => t.client_id));
+    expect(clientIds.has(clientAId)).toBe(true);
+    expect(clientIds.has(clientBId)).toBe(true);
+
+    // Ordered by created_at DESC
+    const timestamps = res.body.map((t) => new Date(t.created_at).getTime());
+    const sorted = [...timestamps].sort((a, b) => b - a);
+    expect(timestamps).toEqual(sorted);
+  });
+
+  it('GET /{practice_id}/client-balances returns one row per client with their latest balance_after', async () => {
+    interface ClientBalanceRow {
+      client_id: string;
+      balance: number;
+      as_of_date: string;
+    }
+
+    const res = await toTypedResponse<ClientBalanceRow[]>(
+      authedRequest(sessionToken).get(`/api/trust/${org.id}/client-balances`)
+    );
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBe(2);
+
+    const byClient = new Map(res.body.map((r) => [r.client_id, r]));
+    expect(byClient.get(clientAId)?.balance).toBe(1500);
+    expect(byClient.get(clientBId)?.balance).toBe(2500);
+
+    // as_of_date is present and matches the most recent transaction timestamp
+    expect(new Date(byClient.get(clientAId)!.as_of_date).toISOString()).toBe(new Date('2026-02-01T00:00:00Z').toISOString());
+    expect(new Date(byClient.get(clientBId)!.as_of_date).toISOString()).toBe(new Date('2026-03-01T00:00:00Z').toISOString());
+  });
+
+  it('GET /{practice_id}/client-balances returns 401 for unauthenticated request', async () => {
+    const res = await orgProtectedRequest.get(`/api/trust/${org.id}/client-balances`);
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the 5 Phase 3 items from issue #233 — minimal read-only endpoints and filter params that let the Cloudflare Worker pull raw records for the Clio gap reports (Trust Ledger, WIP, Originating Attorney, Matters by Attorney, Task Productivity). No schema migrations, no write paths touched.

**Items**

- `GET /api/trust/{practice_id}/transactions` — description tweak to make the org-wide behavior (when `client_id` is omitted) explicit. No code change; the underlying repo already supported this.
- **New** `GET /api/trust/{practice_id}/client-balances` — returns latest `balance_after` per client across the org, plus `as_of_date` for Worker freshness checks. Reuses the `selectDistinctOn` pattern already used by `getLatestBalanceByClient`.
- `GET /api/matters/{practice_id}/{matter_id}/time-entries` — adds `invoiced` filter (`invoice_id IS NULL` when `false`, `IS NOT NULL` when `true`).
- `GET /api/matters/{practice_id}` — adds `responsible_attorney_id` and `originating_attorney_id` filter params.
- **New** `GET /api/matters/{practice_id}/summary/by-originating-attorney` — aggregate counts (`total_matters`, `active_matters`, `closed_matters`) grouped by `originating_attorney_id`. Active = `status <> 'closed'` (Clio's "open" semantics); soft-deleted matters excluded. **Flagging for review.**
- **New** `GET /api/matters/{practice_id}/tasks` — org-wide task listing with `assignee_id` / `status` / `due_before` filters. `due_before` semantics: `due_date < due_before` (excludes tasks with NULL `due_date`).

## Naming convention note

Issue #233 uses camelCase query params (`responsibleAttorneyId`, `assigneeId`, `dueBefore`). Per `CLAUDE.md` rule #7 ("API interfaces are snake_case") and matching every existing query param in this codebase, all new query params are **snake_case**: `responsible_attorney_id`, `originating_attorney_id`, `assignee_id`, `due_before`. **Worker call sites need to use snake_case keys.**

## Routing

The two new top-level routes (`/{practice_id}/tasks`, `/{practice_id}/summary/by-originating-attorney`) are registered on the matters `app` **before** `app.route('/:practice_id', matterSubResources)` so Hono's matcher prefers the literal paths over the `/:practice_id/:id/*` wildcard guarded by `requireMatterAccess()` (which would otherwise reject literals like `"tasks"` / `"summary"` as invalid matter UUIDs).

## Test plan

- [ ] Static: `pnpm run typecheck`, `pnpm run format:check`, `pnpm run lint`
- [ ] Integration tests (added under `test/modules/{trust,matters}/`):
  - [ ] GET trust transactions without `client_id` returns org-wide list, DESC
  - [ ] GET trust client-balances returns one row per client with latest `balance_after` + `as_of_date`
  - [ ] GET time-entries with `invoiced=false` returns only entries where `invoice_id IS NULL`
  - [ ] GET time-entries with `invoiced=true` filters correctly (regression check)
  - [ ] GET time-entries with `billable=true` regression
  - [ ] GET matters with `responsible_attorney_id=<uuid>` filters correctly
  - [ ] GET matters with `originating_attorney_id=<uuid>` filters correctly
  - [ ] GET summary/by-originating-attorney returns one group per attorney with correct counts
  - [ ] GET org tasks filters by `assignee_id` / `status`
  - [ ] GET org tasks with `due_before=<date>` excludes NULL `due_date`
  - [ ] Routing-conflict checks confirm new top-level routes win over the `:id/*` sub-router
  - [ ] 401 checks for unauthenticated requests
- [ ] Manual smoke (`pnpm run dev`):
  - [ ] Hit each new endpoint with curl as an authenticated org member
  - [ ] Confirm OpenAPI docs at `/scalar` show the 3 new routes and 3 new filter params
  - [ ] Confirm `/api/matters/<practice_id>/tasks` is NOT caught by `requireMatterAccess()`

## Out of scope (per issue Non-Goals)

- No report computation logic (Worker does that)
- No data reshaping for reports — raw records only
- No email / PDF / Excel
- No schema migrations
- No changes to trust write endpoints (deposit, withdrawal)

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Matters summary by originating attorney; org-wide task listing with filters (assignee, status, due date); trust client balances endpoint; added attorney and invoiced filters for matter/time-entry listings

* **Documentation**
  * Added Behavioral Guidelines section to contributor docs

* **Chores**
  * Simplified session/onboarding hook behavior (removed automatic active-organization derivation)

* **Tests**
  * Added comprehensive test suites for matters and trust reporting endpoints and route disambiguation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blawby/blawby-backend/pull/261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->