### PR TITLE
fix(preferences): return defaults instead of 404 for users with no row

### DIFF
--- a/src/modules/preferences/services/preferences.service.ts
+++ b/src/modules/preferences/services/preferences.service.ts
@@ -53,7 +53,17 @@ const applyOnboardingDefaults = (stored: Record<string, unknown> | null | undefi
 };
 
 /**
- * Get all preferences for a user
+ * Get all preferences for a user.
+ *
+ * "User has never set any preferences" is a normal, valid state for any new
+ * user — not an error. Return defaults (with empty per-category objects)
+ * instead of 404 so the frontend can render account/settings pages cleanly.
+ *
+ * Pre-fix, the frontend's AccountPage saw the 404 as a thrown HttpError, and
+ * an effect's dep churn re-fired the GET → re-threw → re-rendered, producing
+ * a 260+ console-error render loop on the Account settings page for any new
+ * user. See blawby-ai-chatbot PR #581 audit (U9) and CLAUDE.md "fix the API
+ * contract / source of truth first".
  */
 const getPreferences = async (ctx: ServiceContext): Promise<Preferences> => {
   // CASL Check — verify the user can read preferences
@@ -62,7 +72,26 @@ const getPreferences = async (ctx: ServiceContext): Promise<Preferences> => {
   const [prefs] = await db.select().from(preferences).where(eq(preferences.user_id, ctx.userId)).limit(1);
 
   if (!prefs) {
-    throw new HTTPException(404, { message: 'Preference not found' });
+    // Synthetic "no row yet" response. `id` is a stable per-call UUID so
+    // the response satisfies the Preferences type without lying about
+    // persistence. Callers should not rely on `id` when there's no row;
+    // they get one once they PUT to any category.
+    const now = new Date();
+    const defaultRow: Preferences = {
+      id: '00000000-0000-0000-0000-000000000000',
+      user_id: ctx.userId,
+      general: {},
+      notifications: applyNotificationDefaults(null),
+      security: {},
+      account: {},
+      onboarding: applyOnboardingDefaults(null),
+      organization_id: null,
+      organization: null,
+      product_usage: null,
+      created_at: now,
+      updated_at: now,
+    };
+    return defaultRow;
   }
 
   // Apply defaults to notifications and onboarding fields
@@ -74,7 +103,11 @@ const getPreferences = async (ctx: ServiceContext): Promise<Preferences> => {
 };
 
 /**
- * Get preferences by category
+ * Get preferences by category.
+ *
+ * Returns the category's empty/default shape when the user has no preferences
+ * row yet (a valid empty state, not an error). See `getPreferences` above for
+ * the rationale.
  */
 const getPreferencesByCategory = async (
   category: PreferenceCategory,
@@ -97,7 +130,15 @@ const getPreferencesByCategory = async (
     .limit(1);
 
   if (!row) {
-    throw new HTTPException(404, { message: 'Preference not found' });
+    // No preferences row yet for this user. Return defaults so account/
+    // settings UI renders correctly for a brand-new user.
+    if (category === 'notifications') {
+      return applyNotificationDefaults(null);
+    }
+    if (category === 'onboarding') {
+      return applyOnboardingDefaults(null);
+    }
+    return {};
   }
 
   const categoryData = toRecord(row?.[category]);


### PR DESCRIPTION
## Context

Surfaced by [blawby-ai-chatbot PR #581](https://github.com/Blawby/blawby-ai-chatbot/pull/581) (audit task #15, plan unit U9).

For any brand-new user, `GET /api/preferences` and `GET /api/preferences/{category}` both threw `HTTPException(404, 'Preference not found')`. The frontend's [`AccountPage`](https://github.com/Blawby/blawby-ai-chatbot/blob/staging/src/features/settings/pages/AccountPage.tsx) treats that 404 as a genuine error and the dep-changing effect re-fires the GET → re-throws → re-renders. Result: **260+ console errors in ~2 seconds** on the Account settings page for any new user. Confirmed live in Playwright while auditing the frontend PR — `Failed to load account data: HttpError: Preference not found`.

"User has never set any preferences" is a normal, valid empty state for every new user. Per blawby-ai-chatbot `CLAUDE.md`:

> When an internal API returns errors, nulls, or malformed data, fix the API contract/source of truth first; do not add frontend fallbacks, guards, or workaround logic unless the API behavior is intentionally nullable and documented.

So this is the backend fix.

## Changes

- `getPreferences`: returns a synthetic default `Preferences` shape with per-category defaults (`applyNotificationDefaults(null)`, `applyOnboardingDefaults(null)`, empty objects elsewhere) when the user has no row. Synthetic id is the zero-UUID sentinel so callers can't mistake it for a real PK before they've PUT anything.
- `getPreferencesByCategory`: returns category-specific defaults (notification defaults, onboarding defaults, or `{}`) instead of throwing when the user has no row.
- `updatePreferencesByCategory` still 404s when no row exists — PUT shouldn't auto-create. Row creation stays with `initializeUserPreferences` (called from the `AuthUserSignedUp` listener).

## Verification

- [x] `npm run typecheck` — passes
- [ ] Re-run blawby-ai-chatbot's AccountPage in Playwright after merge — should render cleanly with zero console errors for new users
- [ ] Add backend unit tests (no existing `test/modules/preferences/` directory; would be additive scope — defer to follow-up)

## Related

- Frontend PR: [Blawby/blawby-ai-chatbot#581](https://github.com/Blawby/blawby-ai-chatbot/pull/581) (route-intent consolidation)
- Audit: docs/audits/2026-05-16-session-auth-surface-audit.md in that repo
- Plan unit: U9 in docs/plans/2026-05-16-002-refactor-route-intent-consolidation-plan.md

## Out of scope (separate follow-up PR)

U10 from the same plan — drop the `?? primaryWorkspace` fallback in [`src/shared/middleware/requireAuth.ts:37`](src/shared/middleware/requireAuth.ts). Dormant for the demo user (primaryWorkspace happens to be null), can ship in a focused follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)