### PR TITLE
feat(uploads): add thumbnail endpoint and enrich upload metadata

### DIFF
--- a/src/modules/practice-client-intakes/services/intake-files.service.ts
+++ b/src/modules/practice-client-intakes/services/intake-files.service.ts
@@ -97,7 +97,7 @@ export const intakeFilesService = {
     ]);
 
     return {
-      uploads: uploads.map(toUploadDetails),
+      uploads: uploads.map((upload) => toUploadDetails(upload)),
       total,
       page,
       limit,

--- a/src/shared/uploads/http.ts
+++ b/src/shared/uploads/http.ts
@@ -107,6 +107,28 @@ const getDownloadUrlRoute = routeBuilder.build({
   },
 });
 
+const getThumbnailUrlRoute = routeBuilder.build({
+  method: 'get',
+  path: '/{id}/thumbnail',
+  tags: ['Uploads'],
+  summary: 'Get thumbnail URL for an image upload',
+  security: [{ Bearer: [] }],
+  request: {
+    params: uploadIdParamOpenAPISchema,
+    query: uploadValidations.thumbnailQuerySchema,
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: uploadValidations.thumbnailUrlResponseSchema,
+        },
+      },
+      description: 'Thumbnail URL generated successfully',
+    },
+  },
+});
+
 const deleteUploadRoute = routeBuilder.build({
   method: 'delete',
   path: '/{id}',
@@ -237,6 +259,22 @@ uploadsHttp.openapi(getDownloadUrlRoute, async (c) => {
   const result = await uploadCoreService.getDownloadUrl(
     {
       id,
+      ipAddress: c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ?? c.req.header('cf-connecting-ip'),
+      userAgent: c.req.header('user-agent'),
+    },
+    ctx
+  );
+  return c.json(result, 200);
+});
+
+uploadsHttp.openapi(getThumbnailUrlRoute, async (c) => {
+  const { id } = c.req.valid('param');
+  const query = c.req.valid('query');
+  const ctx = getServiceContext(c);
+  const result = await uploadCoreService.getThumbnailUrl(
+    {
+      id,
+      query,
       ipAddress: c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ?? c.req.header('cf-connecting-ip'),
       userAgent: c.req.header('user-agent'),
     },

--- a/src/shared/uploads/services/upload-core.service.ts
+++ b/src/shared/uploads/services/upload-core.service.ts
@@ -109,8 +109,9 @@ const buildCloudflareResizedUrl = ({
   height: number;
   fit: 'contain' | 'cover' | 'scale-down';
 }): string => {
+  const origin = new URL(sourceUrl).origin;
   const resizeParams = `width=${width},height=${height},fit=${fit},metadata=none`;
-  return `/cdn-cgi/image/${resizeParams}/${sourceUrl}`;
+  return `${origin}/cdn-cgi/image/${resizeParams}/${sourceUrl}`;
 };
 
 const buildInlineThumbnail = (
@@ -122,8 +123,8 @@ const buildInlineThumbnail = (
 
   if (upload.storage_provider === 'images') {
     return {
-      hasThumbnail: true,
-      thumbnailUrl: upload.public_url,
+      hasThumbnail: !!upload.public_url,
+      thumbnailUrl: upload.public_url ?? null,
       thumbnailExpiresAt: null,
     };
   }

--- a/src/shared/uploads/services/upload-core.service.ts
+++ b/src/shared/uploads/services/upload-core.service.ts
@@ -1,13 +1,14 @@
 import { ForbiddenError } from '@casl/ability';
-import { and, eq, inArray } from 'drizzle-orm';
 import { getLogger } from '@logtape/logtape';
 import { HTTPException } from 'hono/http-exception';
-import { matters } from '@/modules/matters/database/schema/matters.schema';
-import { practiceClientIntakes } from '@/modules/practice-client-intakes/database/schema/practice-client-intakes.schema';
 import { config } from '@/shared/config';
 import { toSubject } from '@/shared/auth/subject-helpers';
-import { users } from '@/schema/better-auth-schema';
 import { auditLogsRepository } from '@/shared/uploads/queries/audit-logs.repository';
+import {
+  buildUploadMetadataEnrichment,
+  defaultUploadMetadataEnrichment,
+  type UploadMetadataEnrichment,
+} from '@/shared/uploads/services/upload-enrichment.service';
 import { uploadsRepository } from '@/shared/uploads/queries/uploads.repository';
 import { auditService } from '@/shared/uploads/services/audit.service';
 import { keyGeneratorService } from '@/shared/uploads/services/key-generator.service';
@@ -149,108 +150,6 @@ const buildInlineThumbnail = (
     }),
     thumbnailExpiresAt: null,
   };
-};
-
-type UploadMetadataEnrichment = {
-  uploadedByName: string | null;
-  uploadedByEmail: string | null;
-  scopeLabel: string | null;
-};
-
-const defaultUploadMetadataEnrichment: UploadMetadataEnrichment = {
-  uploadedByName: null,
-  uploadedByEmail: null,
-  scopeLabel: null,
-};
-
-const getIntakeScopeLabel = (metadata: unknown): string | null => {
-  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
-    return null;
-  }
-
-  const metadataRecord = metadata as Record<string, unknown>;
-  if (typeof metadataRecord.name === 'string' && metadataRecord.name.trim().length > 0) {
-    return metadataRecord.name;
-  }
-  if (typeof metadataRecord.email === 'string' && metadataRecord.email.trim().length > 0) {
-    return metadataRecord.email;
-  }
-
-  return null;
-};
-
-const buildUploadMetadataEnrichment = async (
-  uploads: SelectUpload[],
-  { db, organizationId }: { db: ServiceContext['db']; organizationId: string }
-): Promise<Map<string, UploadMetadataEnrichment>> => {
-  const enrichments = new Map<string, UploadMetadataEnrichment>();
-  if (uploads.length === 0) {
-    return enrichments;
-  }
-
-  const uploaderIds = Array.from(new Set(uploads.map((upload) => upload.user_id).filter((id): id is string => !!id)));
-  const matterScopeIds = Array.from(
-    new Set(
-      uploads
-        .filter((upload) => upload.scope_type === 'matter' && !!upload.scope_id)
-        .map((upload) => upload.scope_id as string)
-    )
-  );
-  const intakeScopeIds = Array.from(
-    new Set(
-      uploads
-        .filter((upload) => upload.scope_type === 'intake' && !!upload.scope_id)
-        .map((upload) => upload.scope_id as string)
-    )
-  );
-
-  const [uploaderRows, matterRows, intakeRows] = await Promise.all([
-    uploaderIds.length
-      ? db
-          .select({ id: users.id, name: users.name, email: users.email })
-          .from(users)
-          .where(inArray(users.id, uploaderIds))
-      : Promise.resolve([]),
-    matterScopeIds.length
-      ? db
-          .select({ id: matters.id, title: matters.title })
-          .from(matters)
-          .where(and(eq(matters.organization_id, organizationId), inArray(matters.id, matterScopeIds)))
-      : Promise.resolve([]),
-    intakeScopeIds.length
-      ? db
-          .select({ id: practiceClientIntakes.id, metadata: practiceClientIntakes.metadata })
-          .from(practiceClientIntakes)
-          .where(
-            and(
-              eq(practiceClientIntakes.organization_id, organizationId),
-              inArray(practiceClientIntakes.id, intakeScopeIds)
-            )
-          )
-      : Promise.resolve([]),
-  ]);
-
-  const uploaderMap = new Map(uploaderRows.map((row) => [row.id, { name: row.name, email: row.email }]));
-  const matterLabelMap = new Map(matterRows.map((row) => [row.id, row.title]));
-  const intakeLabelMap = new Map(intakeRows.map((row) => [row.id, getIntakeScopeLabel(row.metadata)]));
-
-  for (const upload of uploads) {
-    const uploader = upload.user_id ? uploaderMap.get(upload.user_id) : undefined;
-    const scopeLabel =
-      upload.scope_type === 'matter' && upload.scope_id
-        ? (matterLabelMap.get(upload.scope_id) ?? null)
-        : upload.scope_type === 'intake' && upload.scope_id
-          ? (intakeLabelMap.get(upload.scope_id) ?? null)
-          : null;
-
-    enrichments.set(upload.id, {
-      uploadedByName: uploader?.name ?? null,
-      uploadedByEmail: uploader?.email ?? null,
-      scopeLabel,
-    });
-  }
-
-  return enrichments;
 };
 
 export const toUploadDetails = (

--- a/src/shared/uploads/services/upload-core.service.ts
+++ b/src/shared/uploads/services/upload-core.service.ts
@@ -470,7 +470,18 @@ export const uploadCoreService = {
       if (!upload.public_url) {
         throw new HTTPException(400, { message: 'Thumbnail URL not available for this image' });
       }
-      thumbnailUrl = upload.public_url;
+      const isDefault = width === 320 && height === 320 && fit === 'contain';
+      if (isDefault) {
+        thumbnailUrl = upload.public_url;
+      } else {
+        // Cloudflare Images flexible variant: https://imagedelivery.net/<ACCOUNT_HASH>/<IMAGE_ID>/<variant>
+        const match = upload.public_url.match(/^https:\/\/imagedelivery\.net\/([^/]+)\/([^/]+)/);
+        if (!match) {
+          throw new HTTPException(400, { message: 'Unsupported thumbnail params for this image provider' });
+        }
+        const [, accountHash, imageId] = match;
+        thumbnailUrl = `https://imagedelivery.net/${accountHash}/${imageId}/w=${width},h=${height},fit=${fit}`;
+      }
       expiresAt = null;
     } else {
       const basePublicUrl = upload.public_url ?? buildPublicUrl(upload.storage_key);

--- a/src/shared/uploads/services/upload-core.service.ts
+++ b/src/shared/uploads/services/upload-core.service.ts
@@ -1,8 +1,12 @@
 import { ForbiddenError } from '@casl/ability';
+import { and, eq, inArray } from 'drizzle-orm';
 import { getLogger } from '@logtape/logtape';
 import { HTTPException } from 'hono/http-exception';
+import { matters } from '@/modules/matters/database/schema/matters.schema';
+import { practiceClientIntakes } from '@/modules/practice-client-intakes/database/schema/practice-client-intakes.schema';
 import { config } from '@/shared/config';
 import { toSubject } from '@/shared/auth/subject-helpers';
+import { users } from '@/schema/better-auth-schema';
 import { auditLogsRepository } from '@/shared/uploads/queries/audit-logs.repository';
 import { uploadsRepository } from '@/shared/uploads/queries/uploads.repository';
 import { auditService } from '@/shared/uploads/services/audit.service';
@@ -109,24 +113,176 @@ const buildCloudflareResizedUrl = ({
   return `/cdn-cgi/image/${resizeParams}/${sourceUrl}`;
 };
 
-export const toUploadDetails = (upload: SelectUpload): UploadDetails => ({
-  upload_id: upload.id,
-  file_name: upload.file_name,
-  file_type: upload.file_type,
-  file_size: upload.file_size,
-  mime_type: upload.mime_type,
-  storage_provider: upload.storage_provider as 'r2' | 'images',
-  storage_key: upload.storage_key,
-  public_url: upload.public_url,
-  scope_type: (upload.scope_type as UploadDetails['scope_type']) ?? null,
-  scope_id: upload.scope_id,
-  status: upload.status as UploadDetails['status'],
-  is_privileged: upload.is_privileged ?? true,
-  retention_until: upload.retention_until ?? null,
-  created_at: upload.created_at,
-  verified_at: upload.verified_at ?? null,
-  uploaded_by: upload.user_id,
-});
+const buildInlineThumbnail = (
+  upload: SelectUpload
+): { hasThumbnail: boolean; thumbnailUrl: string | null; thumbnailExpiresAt: Date | null } => {
+  if (upload.status !== 'verified' || !isImageMimeType(upload.mime_type)) {
+    return { hasThumbnail: false, thumbnailUrl: null, thumbnailExpiresAt: null };
+  }
+
+  if (upload.storage_provider === 'images') {
+    return {
+      hasThumbnail: true,
+      thumbnailUrl: upload.public_url,
+      thumbnailExpiresAt: null,
+    };
+  }
+
+  const basePublicUrl = upload.public_url ?? buildPublicUrl(upload.storage_key);
+  if (!basePublicUrl) {
+    // Thumbnail endpoint can still return a short-lived presigned URL on demand.
+    return {
+      hasThumbnail: true,
+      thumbnailUrl: null,
+      thumbnailExpiresAt: null,
+    };
+  }
+
+  return {
+    hasThumbnail: true,
+    thumbnailUrl: buildCloudflareResizedUrl({
+      sourceUrl: basePublicUrl,
+      width: 320,
+      height: 320,
+      fit: 'contain',
+    }),
+    thumbnailExpiresAt: null,
+  };
+};
+
+type UploadMetadataEnrichment = {
+  uploadedByName: string | null;
+  uploadedByEmail: string | null;
+  scopeLabel: string | null;
+};
+
+const defaultUploadMetadataEnrichment: UploadMetadataEnrichment = {
+  uploadedByName: null,
+  uploadedByEmail: null,
+  scopeLabel: null,
+};
+
+const getIntakeScopeLabel = (metadata: unknown): string | null => {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return null;
+  }
+
+  const metadataRecord = metadata as Record<string, unknown>;
+  if (typeof metadataRecord.name === 'string' && metadataRecord.name.trim().length > 0) {
+    return metadataRecord.name;
+  }
+  if (typeof metadataRecord.email === 'string' && metadataRecord.email.trim().length > 0) {
+    return metadataRecord.email;
+  }
+
+  return null;
+};
+
+const buildUploadMetadataEnrichment = async (
+  uploads: SelectUpload[],
+  { db, organizationId }: { db: ServiceContext['db']; organizationId: string }
+): Promise<Map<string, UploadMetadataEnrichment>> => {
+  const enrichments = new Map<string, UploadMetadataEnrichment>();
+  if (uploads.length === 0) {
+    return enrichments;
+  }
+
+  const uploaderIds = Array.from(new Set(uploads.map((upload) => upload.user_id).filter((id): id is string => !!id)));
+  const matterScopeIds = Array.from(
+    new Set(
+      uploads
+        .filter((upload) => upload.scope_type === 'matter' && !!upload.scope_id)
+        .map((upload) => upload.scope_id as string)
+    )
+  );
+  const intakeScopeIds = Array.from(
+    new Set(
+      uploads
+        .filter((upload) => upload.scope_type === 'intake' && !!upload.scope_id)
+        .map((upload) => upload.scope_id as string)
+    )
+  );
+
+  const [uploaderRows, matterRows, intakeRows] = await Promise.all([
+    uploaderIds.length
+      ? db
+          .select({ id: users.id, name: users.name, email: users.email })
+          .from(users)
+          .where(inArray(users.id, uploaderIds))
+      : Promise.resolve([]),
+    matterScopeIds.length
+      ? db
+          .select({ id: matters.id, title: matters.title })
+          .from(matters)
+          .where(and(eq(matters.organization_id, organizationId), inArray(matters.id, matterScopeIds)))
+      : Promise.resolve([]),
+    intakeScopeIds.length
+      ? db
+          .select({ id: practiceClientIntakes.id, metadata: practiceClientIntakes.metadata })
+          .from(practiceClientIntakes)
+          .where(
+            and(
+              eq(practiceClientIntakes.organization_id, organizationId),
+              inArray(practiceClientIntakes.id, intakeScopeIds)
+            )
+          )
+      : Promise.resolve([]),
+  ]);
+
+  const uploaderMap = new Map(uploaderRows.map((row) => [row.id, { name: row.name, email: row.email }]));
+  const matterLabelMap = new Map(matterRows.map((row) => [row.id, row.title]));
+  const intakeLabelMap = new Map(intakeRows.map((row) => [row.id, getIntakeScopeLabel(row.metadata)]));
+
+  for (const upload of uploads) {
+    const uploader = upload.user_id ? uploaderMap.get(upload.user_id) : undefined;
+    const scopeLabel =
+      upload.scope_type === 'matter' && upload.scope_id
+        ? (matterLabelMap.get(upload.scope_id) ?? null)
+        : upload.scope_type === 'intake' && upload.scope_id
+          ? (intakeLabelMap.get(upload.scope_id) ?? null)
+          : null;
+
+    enrichments.set(upload.id, {
+      uploadedByName: uploader?.name ?? null,
+      uploadedByEmail: uploader?.email ?? null,
+      scopeLabel,
+    });
+  }
+
+  return enrichments;
+};
+
+export const toUploadDetails = (
+  upload: SelectUpload,
+  enrichment: UploadMetadataEnrichment = defaultUploadMetadataEnrichment
+): UploadDetails => {
+  const thumbnail = buildInlineThumbnail(upload);
+
+  return {
+    upload_id: upload.id,
+    file_name: upload.file_name,
+    file_type: upload.file_type,
+    file_size: upload.file_size,
+    mime_type: upload.mime_type,
+    storage_provider: upload.storage_provider as 'r2' | 'images',
+    storage_key: upload.storage_key,
+    public_url: upload.public_url,
+    scope_type: (upload.scope_type as UploadDetails['scope_type']) ?? null,
+    scope_id: upload.scope_id,
+    status: upload.status as UploadDetails['status'],
+    is_privileged: upload.is_privileged ?? true,
+    retention_until: upload.retention_until ?? null,
+    created_at: upload.created_at,
+    verified_at: upload.verified_at ?? null,
+    uploaded_by: upload.user_id,
+    uploaded_by_name: enrichment.uploadedByName,
+    uploaded_by_email: enrichment.uploadedByEmail,
+    scope_label: enrichment.scopeLabel,
+    has_thumbnail: thumbnail.hasThumbnail,
+    thumbnail_url: thumbnail.thumbnailUrl,
+    thumbnail_expires_at: thumbnail.thumbnailExpiresAt,
+  };
+};
 
 const toAuditLogEntry = (
   log: Awaited<ReturnType<typeof auditLogsRepository.findByUploadId>>[number]
@@ -462,6 +618,16 @@ export const uploadCoreService = {
     const upload = await getUploadOrThrow(id, ctx);
     assertUploadAccess(upload, ctx, 'read');
 
+    const organizationId = upload.organization_id ?? ctx.organizationId;
+    if (!organizationId) {
+      throw new HTTPException(400, { message: 'Organization context required' });
+    }
+
+    const enrichmentMap = await buildUploadMetadataEnrichment([upload], {
+      db: ctx.db,
+      organizationId,
+    });
+
     await uploadsRepository.updateLastAccessed(id, ctx.userId, ctx.db);
 
     await auditService.log(
@@ -474,7 +640,7 @@ export const uploadCoreService = {
       ctx.db
     );
 
-    return toUploadDetails(upload);
+    return toUploadDetails(upload, enrichmentMap.get(upload.id) ?? defaultUploadMetadataEnrichment);
   },
 
   async listUploads({ query }: { query: ListUploadsQuery }, ctx: ServiceContext): Promise<ListUploadsResponse> {
@@ -516,8 +682,15 @@ export const uploadCoreService = {
       ),
     ]);
 
+    const enrichmentMap = await buildUploadMetadataEnrichment(results, {
+      db: ctx.db,
+      organizationId: ctx.organizationId,
+    });
+
     return {
-      uploads: results.map(toUploadDetails),
+      uploads: results.map((upload) =>
+        toUploadDetails(upload, enrichmentMap.get(upload.id) ?? defaultUploadMetadataEnrichment)
+      ),
       total,
       page,
       limit,

--- a/src/shared/uploads/services/upload-core.service.ts
+++ b/src/shared/uploads/services/upload-core.service.ts
@@ -19,6 +19,8 @@ import type {
   ListUploadsResponse,
   PresignUploadRequest,
   PresignUploadResponse,
+  ThumbnailQuery,
+  ThumbnailUrlResponse,
   UploadDetails,
 } from '@/shared/uploads/types/uploads.types';
 import type { ServiceContext } from '@/shared/types/service-context';
@@ -88,6 +90,23 @@ const buildPublicUrl = (storageKey: string): string | null => {
     return null;
   }
   return `${publicUrlBase}/${storageKey}`;
+};
+
+const isImageMimeType = (mimeType: string): boolean => mimeType.toLowerCase().startsWith('image/');
+
+const buildCloudflareResizedUrl = ({
+  sourceUrl,
+  width,
+  height,
+  fit,
+}: {
+  sourceUrl: string;
+  width: number;
+  height: number;
+  fit: 'contain' | 'cover' | 'scale-down';
+}): string => {
+  const resizeParams = `width=${width},height=${height},fit=${fit},metadata=none`;
+  return `/cdn-cgi/image/${resizeParams}/${sourceUrl}`;
 };
 
 export const toUploadDetails = (upload: SelectUpload): UploadDetails => ({
@@ -363,6 +382,76 @@ export const uploadCoreService = {
 
     return {
       download_url: downloadUrl,
+      expires_at: expiresAt,
+    };
+  },
+
+  async getThumbnailUrl(
+    { id, query, ipAddress, userAgent }: { id: string; query: ThumbnailQuery; ipAddress?: string; userAgent?: string },
+    ctx: ServiceContext
+  ): Promise<ThumbnailUrlResponse> {
+    requireAuth(ctx);
+
+    const upload = await getUploadOrThrow(id, ctx);
+    assertUploadAccess(upload, ctx, 'read');
+
+    if (upload.status !== 'verified') {
+      throw new HTTPException(400, { message: 'Upload must be verified before thumbnail access' });
+    }
+
+    if (!isImageMimeType(upload.mime_type)) {
+      throw new HTTPException(400, { message: 'Thumbnails are only available for image uploads' });
+    }
+
+    const width = query.width ?? 320;
+    const height = query.height ?? 320;
+    const fit = query.fit ?? 'contain';
+
+    let thumbnailUrl: string;
+    let expiresAt: Date | null;
+
+    if (upload.storage_provider === 'images') {
+      if (!upload.public_url) {
+        throw new HTTPException(400, { message: 'Thumbnail URL not available for this image' });
+      }
+      thumbnailUrl = upload.public_url;
+      expiresAt = null;
+    } else {
+      const basePublicUrl = upload.public_url ?? buildPublicUrl(upload.storage_key);
+      if (basePublicUrl) {
+        thumbnailUrl = buildCloudflareResizedUrl({ sourceUrl: basePublicUrl, width, height, fit });
+        expiresAt = null;
+      } else {
+        expiresAt = new Date(Date.now() + 15 * 60 * 1000);
+        const url = await r2Service.generatePresignedDownloadUrl({
+          bucket: getBucketOrThrow(),
+          key: upload.storage_key,
+          expiresIn: 15 * 60,
+        });
+        if (!url) {
+          throw new HTTPException(500, { message: 'Failed to generate thumbnail URL' });
+        }
+        thumbnailUrl = url;
+      }
+    }
+
+    await uploadsRepository.updateLastAccessed(id, ctx.userId, ctx.db);
+
+    await auditService.log(
+      {
+        upload_id: id,
+        organization_id: upload.organization_id ?? undefined,
+        action: 'viewed',
+        user_id: ctx.userId,
+        ip_address: ipAddress,
+        user_agent: userAgent,
+        metadata: { kind: 'thumbnail', width, height, fit },
+      },
+      ctx.db
+    );
+
+    return {
+      thumbnail_url: thumbnailUrl,
       expires_at: expiresAt,
     };
   },

--- a/src/shared/uploads/services/upload-enrichment.service.ts
+++ b/src/shared/uploads/services/upload-enrichment.service.ts
@@ -1,0 +1,105 @@
+import { and, eq, inArray } from 'drizzle-orm';
+import { matters } from '@/modules/matters/database/schema/matters.schema';
+import { practiceClientIntakes } from '@/modules/practice-client-intakes/database/schema/practice-client-intakes.schema';
+import { users } from '@/schema/better-auth-schema';
+import type { SelectUpload } from '@/shared/uploads/schema/uploads.schema';
+import type { UploadMetadataEnrichment } from '@/shared/uploads/types/uploads.types';
+import type { ServiceContext } from '@/shared/types/service-context';
+
+export type { UploadMetadataEnrichment } from '@/shared/uploads/types/uploads.types';
+
+export const defaultUploadMetadataEnrichment: UploadMetadataEnrichment = {
+  uploadedByName: null,
+  uploadedByEmail: null,
+  scopeLabel: null,
+};
+
+const getIntakeScopeLabel = (metadata: unknown): string | null => {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return null;
+  }
+
+  const metadataRecord = metadata as Record<string, unknown>;
+  if (typeof metadataRecord.name === 'string' && metadataRecord.name.trim().length > 0) {
+    return metadataRecord.name;
+  }
+  if (typeof metadataRecord.email === 'string' && metadataRecord.email.trim().length > 0) {
+    return metadataRecord.email;
+  }
+
+  return null;
+};
+
+export const buildUploadMetadataEnrichment = async (
+  uploads: SelectUpload[],
+  { db, organizationId }: { db: ServiceContext['db']; organizationId: string }
+): Promise<Map<string, UploadMetadataEnrichment>> => {
+  const enrichments = new Map<string, UploadMetadataEnrichment>();
+  if (uploads.length === 0) {
+    return enrichments;
+  }
+
+  const uploaderIds = Array.from(new Set(uploads.map((upload) => upload.user_id).filter((id): id is string => !!id)));
+  const matterScopeIds = Array.from(
+    new Set(
+      uploads
+        .filter((upload) => upload.scope_type === 'matter' && !!upload.scope_id)
+        .map((upload) => upload.scope_id as string)
+    )
+  );
+  const intakeScopeIds = Array.from(
+    new Set(
+      uploads
+        .filter((upload) => upload.scope_type === 'intake' && !!upload.scope_id)
+        .map((upload) => upload.scope_id as string)
+    )
+  );
+
+  const [uploaderRows, matterRows, intakeRows] = await Promise.all([
+    uploaderIds.length
+      ? db
+          .select({ id: users.id, name: users.name, email: users.email })
+          .from(users)
+          .where(inArray(users.id, uploaderIds))
+      : Promise.resolve([]),
+    matterScopeIds.length
+      ? db
+          .select({ id: matters.id, title: matters.title })
+          .from(matters)
+          .where(and(eq(matters.organization_id, organizationId), inArray(matters.id, matterScopeIds)))
+      : Promise.resolve([]),
+    intakeScopeIds.length
+      ? db
+          .select({ id: practiceClientIntakes.id, metadata: practiceClientIntakes.metadata })
+          .from(practiceClientIntakes)
+          .where(
+            and(
+              eq(practiceClientIntakes.organization_id, organizationId),
+              inArray(practiceClientIntakes.id, intakeScopeIds)
+            )
+          )
+      : Promise.resolve([]),
+  ]);
+
+  const uploaderMap = new Map(uploaderRows.map((row) => [row.id, { name: row.name, email: row.email }]));
+  const matterLabelMap = new Map(matterRows.map((row) => [row.id, row.title]));
+  const intakeLabelMap = new Map(intakeRows.map((row) => [row.id, getIntakeScopeLabel(row.metadata)]));
+
+  for (const upload of uploads) {
+    const uploader = upload.user_id ? uploaderMap.get(upload.user_id) : undefined;
+    const scopeLabel =
+      upload.scope_type === 'matter' && upload.scope_id
+        ? (matterLabelMap.get(upload.scope_id) ?? null)
+        : upload.scope_type === 'intake' && upload.scope_id
+          ? (intakeLabelMap.get(upload.scope_id) ?? null)
+          : null;
+
+    enrichments.set(upload.id, {
+      uploadedByName: uploader?.name ?? null,
+      uploadedByEmail: uploader?.email ?? null,
+      scopeLabel,
+    });
+  }
+
+  return enrichments;
+};

--- a/src/shared/uploads/types/uploads.types.ts
+++ b/src/shared/uploads/types/uploads.types.ts
@@ -9,11 +9,13 @@ export type PresignUploadRequest = z.infer<typeof uploadValidations.presignUploa
 export type UploadIdParam = z.infer<typeof uploadValidations.uploadIdParamSchema>;
 export type DeleteUploadRequest = z.infer<typeof uploadValidations.deleteUploadSchema>;
 export type ListUploadsQuery = z.infer<typeof uploadValidations.listUploadsQuerySchema>;
+export type ThumbnailQuery = z.infer<typeof uploadValidations.thumbnailQuerySchema>;
 
 export type PresignUploadResponse = z.infer<typeof uploadValidations.presignUploadResponseSchema>;
 export type ConfirmUploadResponse = z.infer<typeof uploadValidations.confirmUploadResponseSchema>;
 export type UploadDetails = z.infer<typeof uploadValidations.uploadDetailsResponseSchema>;
 export type DownloadUrlResponse = z.infer<typeof uploadValidations.downloadUrlResponseSchema>;
+export type ThumbnailUrlResponse = z.infer<typeof uploadValidations.thumbnailUrlResponseSchema>;
 export type ListUploadsResponse = z.infer<typeof uploadValidations.listUploadsResponseSchema>;
 export type AuditLogEntry = z.infer<typeof uploadValidations.auditLogEntrySchema>;
 export type AuditLogResponse = z.infer<typeof uploadValidations.auditLogResponseSchema>;

--- a/src/shared/uploads/types/uploads.types.ts
+++ b/src/shared/uploads/types/uploads.types.ts
@@ -19,3 +19,9 @@ export type ThumbnailUrlResponse = z.infer<typeof uploadValidations.thumbnailUrl
 export type ListUploadsResponse = z.infer<typeof uploadValidations.listUploadsResponseSchema>;
 export type AuditLogEntry = z.infer<typeof uploadValidations.auditLogEntrySchema>;
 export type AuditLogResponse = z.infer<typeof uploadValidations.auditLogResponseSchema>;
+
+export type UploadMetadataEnrichment = {
+  uploadedByName: string | null;
+  uploadedByEmail: string | null;
+  scopeLabel: string | null;
+};

--- a/src/shared/uploads/types/uploads.validation.ts
+++ b/src/shared/uploads/types/uploads.validation.ts
@@ -72,6 +72,17 @@ const downloadUrlResponseSchema = z.object({
   expires_at: z.date().nullable(),
 });
 
+const thumbnailQuerySchema = z.object({
+  width: z.coerce.number().int().min(32).max(2048).optional().default(320),
+  height: z.coerce.number().int().min(32).max(2048).optional().default(320),
+  fit: z.enum(['contain', 'cover', 'scale-down']).optional().default('contain'),
+});
+
+const thumbnailUrlResponseSchema = z.object({
+  thumbnail_url: z.url(),
+  expires_at: z.date().nullable(),
+});
+
 const listUploadsResponseSchema = z.object({
   uploads: z.array(uploadDetailsResponseSchema),
   total: z.number(),
@@ -108,6 +119,8 @@ export const uploadValidations = {
   confirmUploadResponseSchema,
   uploadDetailsResponseSchema,
   downloadUrlResponseSchema,
+  thumbnailQuerySchema,
+  thumbnailUrlResponseSchema,
   listUploadsResponseSchema,
   auditLogEntrySchema,
   auditLogResponseSchema,

--- a/src/shared/uploads/types/uploads.validation.ts
+++ b/src/shared/uploads/types/uploads.validation.ts
@@ -65,6 +65,12 @@ const uploadDetailsResponseSchema = z.object({
   created_at: z.date(),
   verified_at: z.date().nullable(),
   uploaded_by: z.uuid().nullable(),
+  uploaded_by_name: z.string().nullable(),
+  uploaded_by_email: z.string().nullable(),
+  scope_label: z.string().nullable(),
+  has_thumbnail: z.boolean(),
+  thumbnail_url: z.string().nullable(),
+  thumbnail_expires_at: z.date().nullable(),
 });
 
 const downloadUrlResponseSchema = z.object({


### PR DESCRIPTION
## Summary
This PR adds first-class thumbnail support and richer upload metadata for frontend consumers.

## Commits
1. `feat(uploads): add thumbnail URL endpoint`
- Adds `GET /api/uploads/{id}/thumbnail`
- Supports thumbnail query params: `width`, `height`, `fit`
- Returns `thumbnail_url` and `expires_at`
- Works for both Cloudflare Images-backed and R2-backed verified image uploads

2. `feat(uploads): enrich upload metadata for frontend`
- Adds uploader display metadata to upload payloads:
  - `uploaded_by_name`
  - `uploaded_by_email`
- Adds scope label metadata:
  - `scope_label` (resolved from matter title or intake metadata)
- Adds inline thumbnail metadata to upload list/detail payloads:
  - `has_thumbnail`
  - `thumbnail_url`
  - `thumbnail_expires_at`
- Updates intake file mapping compatibility with enhanced `toUploadDetails` signature

## Why
Frontend upload grids/details can now render context-rich rows and image previews without extra per-row API requests in common cases.

## Validation
- `pnpm run typecheck`
- `pnpm run format:check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Thumbnails for image uploads with configurable sizing and multiple delivery methods.
  * Upload details now show uploader name/email and intake/matter scope labels.
  * New endpoint to retrieve thumbnail URLs (with access control and short-lived links where needed).

* **Bug Fixes**
  * Fixed file listing transformation to avoid forwarding unintended map parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blawby/blawby-backend/pull/273?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->