### PR TITLE
feat(practice): enhance practice management with new repository methods and serialization

### DIFF
--- a/src/modules/practice/database/queries/address.repository.ts
+++ b/src/modules/practice/database/queries/address.repository.ts
@@ -1,7 +1,10 @@
-import { eq, and } from 'drizzle-orm';
+import { eq, and, inArray } from 'drizzle-orm';
 import { addresses } from '@/modules/practice/database/schema/addresses.schema';
 import type { AddressData } from '@/modules/practice/types/addresses.types';
-import type { db } from '@/shared/database';
+import { db } from '@/shared/database';
+
+export const findAddressesByIds = async (addressIds: string[]): Promise<(typeof addresses.$inferSelect)[]> =>
+  addressIds.length === 0 ? [] : await db.select().from(addresses).where(inArray(addresses.id, addressIds));
 
 /**
  * Upsert an address within a transaction.

--- a/src/modules/practice/database/queries/organization.repository.ts
+++ b/src/modules/practice/database/queries/organization.repository.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm';
 import type { Organization, NewOrganization } from '@/modules/practice/types/organization.types';
 import { organizations } from '@/schema/better-auth-schema';
 import { db } from '@/shared/database';
@@ -20,6 +20,9 @@ const findBySlug = async (slug: string): Promise<Organization | null> => {
   return organization || null;
 };
 
+const findByIds = async (ids: string[]): Promise<Organization[]> =>
+  ids.length === 0 ? [] : await db.select().from(organizations).where(inArray(organizations.id, ids));
+
 const update = async (id: string, data: Partial<Omit<NewOrganization, 'id'>>): Promise<Organization | null> => {
   const [organization] = await db.update(organizations).set(data).where(eq(organizations.id, id)).returning();
 
@@ -31,6 +34,7 @@ const update = async (id: string, data: Partial<Omit<NewOrganization, 'id'>>): P
  */
 export const organizationRepository = {
   findById,
+  findByIds,
   findBySlug,
   update,
 };

--- a/src/modules/practice/database/queries/practice-details.repository.ts
+++ b/src/modules/practice/database/queries/practice-details.repository.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import {
   practiceDetails,
@@ -23,6 +23,11 @@ export const findPracticeDetailsByOrganization = async (
       services: true,
     },
   });
+
+export const findPracticeDetailsByOrganizations = async (organizationIds: string[]): Promise<PracticeDetails[]> =>
+  organizationIds.length === 0
+    ? []
+    : await db.select().from(practiceDetails).where(inArray(practiceDetails.organization_id, organizationIds));
 
 export const findPracticeWithOrganization = async (
   organizationId: string

--- a/src/modules/practice/database/queries/practice-services.repository.ts
+++ b/src/modules/practice/database/queries/practice-services.repository.ts
@@ -8,6 +8,11 @@ import { db } from '@/shared/database';
 const findServicesByOrganization = async (organizationId: string): Promise<PracticeService[]> =>
   await db.select().from(practiceServices).where(eq(practiceServices.organization_id, organizationId));
 
+const findServicesByOrganizations = async (organizationIds: string[]): Promise<PracticeService[]> =>
+  organizationIds.length === 0
+    ? []
+    : await db.select().from(practiceServices).where(inArray(practiceServices.organization_id, organizationIds));
+
 /**
  * Upsert services for an organization within a transaction
  * Handles creating new ones, updating existing ones, and deleting removed ones.
@@ -87,6 +92,7 @@ const findById = async (id: string): Promise<PracticeService | undefined> => {
 
 export const practiceServicesRepository = {
   findServicesByOrganization,
+  findServicesByOrganizations,
   syncServicesTx,
   findById,
 };

--- a/src/modules/practice/serializers/practice.serializer.ts
+++ b/src/modules/practice/serializers/practice.serializer.ts
@@ -1,0 +1,55 @@
+import type { PracticeDetails } from '@/modules/practice/database/schema/practice.schema';
+import type { Organization } from '@/modules/practice/types/organization.types';
+import type { PracticeResponse } from '@/modules/practice/types/practice.types';
+import type { Address } from '@/shared/validations/address';
+
+export type PracticeServiceResponseItem = {
+  id: string;
+  name: string;
+  key: string;
+};
+
+export interface PracticeSerializationInput {
+  organization: Organization;
+  details: PracticeDetails;
+  services: PracticeServiceResponseItem[];
+  address: Address | null;
+}
+
+const getLatestUpdatedAt = (organization: Organization, details: PracticeDetails): string => {
+  const detailsUpdatedAt = details.updated_at;
+  const latest =
+    detailsUpdatedAt.getTime() > organization.updatedAt.getTime() ? detailsUpdatedAt : organization.updatedAt;
+
+  return latest.toISOString();
+};
+
+export const serializePractice = ({
+  organization,
+  details,
+  services,
+  address,
+}: PracticeSerializationInput): PracticeResponse => ({
+  id: organization.id,
+  slug: organization.slug,
+  name: organization.name,
+  logo: organization.logo,
+  business_phone: details.business_phone,
+  business_email: details.business_email,
+  website: details.website,
+  consultation_fee: details.consultation_fee,
+  payment_url: details.payment_url,
+  calendly_url: details.calendly_url,
+  intro_message: details.intro_message,
+  overview: details.overview,
+  accent_color: details.accent_color,
+  is_public: details.is_public,
+  billing_increment_minutes: details.billing_increment_minutes,
+  payment_link_enabled: organization.paymentLinkEnabled,
+  services,
+  service_states: details.service_states,
+  supported_states: details.supported_states,
+  address,
+  created_at: organization.createdAt.toISOString(),
+  updated_at: getLatestUpdatedAt(organization, details),
+});

--- a/src/modules/practice/services/practice-details-management.service.ts
+++ b/src/modules/practice/services/practice-details-management.service.ts
@@ -5,14 +5,14 @@ import { ForbiddenError } from '@casl/ability';
 import { organizationRepository } from '@/modules/practice/database/queries/organization.repository';
 import { findPracticeDetailsByOrganization } from '@/modules/practice/database/queries/practice-details.repository';
 import { organizationService } from '@/modules/practice/services/organization.service';
+import { loadPracticeResponseById } from '@/modules/practice/services/practice-response.loader';
 import {
   buildPracticeDetailsDeletedPayload,
   findAndDeletePracticeDetails,
   upsertDetailsTransaction,
 } from '@/modules/practice/services/practice-management.helpers';
-import type { PracticeDetailsResponse } from '@/modules/practice/types/practice-details.types';
 import type { UpsertPracticeDetailsParams } from '@/modules/practice/types/practice-management.types';
-import type { OrganizationRequestParams } from '@/modules/practice/types/practice.types';
+import type { OrganizationRequestParams, PracticeResponse } from '@/modules/practice/types/practice.types';
 import { db } from '@/shared/database';
 import { PracticeDeleted, PracticeDetailsDeleted, PracticeSwitched } from '@/shared/events/definitions';
 import type { ServiceContext } from '@/shared/types/service-context';
@@ -31,7 +31,7 @@ export const practiceDetailsManagementService = {
   async upsertPracticeDetails(
     { organizationId, data }: UpsertPracticeDetailsParams,
     ctx: ServiceContext
-  ): Promise<PracticeDetailsResponse> {
+  ): Promise<PracticeResponse> {
     ForbiddenError.from(ctx.ability).throwUnlessCan('update', 'Organization');
 
     const { user } = ctx;
@@ -43,7 +43,7 @@ export const practiceDetailsManagementService = {
 
       const existing = await findPracticeDetailsByOrganization(organizationId);
 
-      const result = await db.transaction(async (tx) =>
+      await db.transaction(async (tx) =>
         upsertDetailsTransaction(tx, ctx, {
           organizationId,
           userId: user.id,
@@ -53,26 +53,12 @@ export const practiceDetailsManagementService = {
         })
       );
 
-      const responseData: PracticeDetailsResponse = {
-        ...result.details,
-        organization_id: organizationId,
-        address: result.addressResult
-          ? {
-              line1: result.addressResult.line1 ?? undefined,
-              line2: result.addressResult.line2 ?? undefined,
-              city: result.addressResult.city ?? undefined,
-              state: result.addressResult.state ?? undefined,
-              postal_code: result.addressResult.postal_code ?? undefined,
-              country: result.addressResult.country ?? undefined,
-            }
-          : null,
-        services: result.syncedServices.map((s) => ({ id: s.id, name: s.name, key: s.key })),
-        name: organization.name,
-        logo: organization.logo ?? null,
-        payment_link_enabled: organization?.paymentLinkEnabled ?? false,
-      };
+      const practice = await loadPracticeResponseById(organizationId);
+      if (!practice) {
+        throw new HTTPException(500, { message: 'Failed to load saved practice details' });
+      }
 
-      return responseData;
+      return practice;
     } catch (error) {
       if (error instanceof HTTPException) {
         throw error;

--- a/src/modules/practice/services/practice-management.helpers.ts
+++ b/src/modules/practice/services/practice-management.helpers.ts
@@ -10,13 +10,9 @@ import type {
   DetailsFieldKeys,
   UpsertDetailsTransactionParams,
 } from '@/modules/practice/types/practice-management.types';
-import type { OrganizationApiShape, PracticeWithDetails } from '@/modules/practice/types/practice.types';
-import betterAuthUtils from '@/shared/auth/utils/betterAuthUtils';
 import { db } from '@/shared/database';
 import { PracticeDetailsCreated, PracticeDetailsUpdated, PracticeDetailsDeleted } from '@/shared/events/definitions';
 import type { ServiceContext } from '@/shared/types/service-context';
-
-const { parseBetterAuthMetadata } = betterAuthUtils;
 
 export const DETAILS_FIELD_KEYS: DetailsFieldKeys[] = [
   'business_phone',
@@ -35,22 +31,6 @@ export const DETAILS_FIELD_KEYS: DetailsFieldKeys[] = [
   'address',
   'accent_color',
 ];
-
-export const buildPracticeWithDetails = (
-  organization: OrganizationApiShape,
-  practiceDetails: PracticeDetails | null
-): PracticeWithDetails => {
-  const { paymentLinkEnabled, createdAt, updatedAt, ...rest } = organization;
-
-  return {
-    ...practiceDetails,
-    ...rest,
-    metadata: parseBetterAuthMetadata(organization.metadata),
-    payment_link_enabled: paymentLinkEnabled ?? null,
-    created_at: createdAt ?? new Date(),
-    updated_at: updatedAt ?? undefined,
-  };
-};
 
 export const upsertDetailsTransaction = async (
   tx: typeof db,

--- a/src/modules/practice/services/practice-management.service.ts
+++ b/src/modules/practice/services/practice-management.service.ts
@@ -6,15 +6,12 @@ import { organizationRepository } from '@/modules/practice/database/queries/orga
 import { findPracticeDetailsByOrganization } from '@/modules/practice/database/queries/practice-details.repository';
 import type { PracticeDetails } from '@/modules/practice/database/schema/practice.schema';
 import { organizationService } from '@/modules/practice/services/organization.service';
-import {
-  DETAILS_FIELD_KEYS,
-  buildPracticeWithDetails,
-  upsertDetailsTransaction,
-} from '@/modules/practice/services/practice-management.helpers';
+import { DETAILS_FIELD_KEYS, upsertDetailsTransaction } from '@/modules/practice/services/practice-management.helpers';
+import { loadPracticeResponseById } from '@/modules/practice/services/practice-response.loader';
 import type { CreatePracticeParams, UpdatePracticeParams } from '@/modules/practice/types/practice-management.types';
 import type {
   UpdatePracticeRequest,
-  PracticeWithDetails,
+  PracticeResponse,
   OrganizationApiShape,
 } from '@/modules/practice/types/practice.types';
 import { practiceValidations } from '@/modules/practice/validations/practice.validation';
@@ -38,10 +35,7 @@ export const practiceManagementService = {
   /**
    * Create a new practice
    */
-  async createPractice(
-    { data }: CreatePracticeParams,
-    ctx: ServiceContext
-  ): Promise<{ practice: PracticeWithDetails }> {
+  async createPractice({ data }: CreatePracticeParams, ctx: ServiceContext): Promise<{ practice: PracticeResponse }> {
     const { user } = ctx;
     try {
       const organizationData = omit(data, DETAILS_FIELD_KEYS);
@@ -86,9 +80,12 @@ export const practiceManagementService = {
         user_email: user.email,
       });
 
-      return {
-        practice: buildPracticeWithDetails(organization, practiceDetails),
-      };
+      const practice = await loadPracticeResponseById(organization.id);
+      if (!practice) {
+        throw new HTTPException(500, { message: 'Failed to load saved practice' });
+      }
+
+      return { practice };
     } catch (error) {
       if (error instanceof HTTPException) {
         throw error;
@@ -111,7 +108,7 @@ export const practiceManagementService = {
   async updatePractice(
     { organizationId, data }: UpdatePracticeParams,
     ctx: ServiceContext
-  ): Promise<{ practice: PracticeWithDetails }> {
+  ): Promise<{ practice: PracticeResponse }> {
     ForbiddenError.from(ctx.ability).throwUnlessCan('update', 'Organization');
 
     const { user } = ctx;
@@ -201,9 +198,12 @@ export const practiceManagementService = {
         user_email: user.email,
       });
 
-      return {
-        practice: buildPracticeWithDetails(organization, practiceDetails),
-      };
+      const practice = await loadPracticeResponseById(organizationId);
+      if (!practice) {
+        throw new HTTPException(500, { message: 'Failed to load saved practice' });
+      }
+
+      return { practice };
     } catch (error) {
       if (error instanceof HTTPException) {
         throw error;

--- a/src/modules/practice/services/practice-queries.service.ts
+++ b/src/modules/practice/services/practice-queries.service.ts
@@ -1,45 +1,17 @@
 import { getLogger } from '@logtape/logtape';
-import { eq } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
 import { ForbiddenError } from '@casl/ability';
 
 import { organizationRepository } from '@/modules/practice/database/queries/organization.repository';
-import { findPracticeDetailsByOrganization } from '@/modules/practice/database/queries/practice-details.repository';
-import { practiceServicesRepository } from '@/modules/practice/database/queries/practice-services.repository';
-import { addresses as addressesTable } from '@/modules/practice/database/schema/addresses.schema';
 import { organizationService } from '@/modules/practice/services/organization.service';
-import type { PracticeDetailsResponse } from '@/modules/practice/types/practice-details.types';
-import type { PracticeWithDetails, OrganizationRequestParams } from '@/modules/practice/types/practice.types';
-import betterAuthUtils from '@/shared/auth/utils/betterAuthUtils';
-import { db } from '@/shared/database';
-import type { Organization } from '@/shared/types/BetterAuth';
+import {
+  loadPracticeResponseById,
+  loadPracticeResponsesForOrganizationIds,
+} from '@/modules/practice/services/practice-response.loader';
+import type { PracticeResponse, OrganizationRequestParams } from '@/modules/practice/types/practice.types';
 import type { ServiceContext } from '@/shared/types/service-context';
-import type { Address } from '@/shared/validations/address';
 
-const { parseBetterAuthMetadata } = betterAuthUtils;
 const logger = getLogger(['practice', 'queries-service']);
-
-// --- Local Helpers ---
-
-const fetchAddressData = async (addressId: string | null): Promise<Address | null> => {
-  if (!addressId) {
-    return null;
-  }
-
-  const [address] = await db.select().from(addressesTable).where(eq(addressesTable.id, addressId));
-
-  if (address) {
-    return {
-      line1: address.line1 ?? undefined,
-      line2: address.line2 ?? undefined,
-      city: address.city ?? undefined,
-      state: address.state ?? undefined,
-      postal_code: address.postal_code ?? undefined,
-      country: address.country ?? undefined,
-    };
-  }
-  return null;
-};
 
 // --- Service ---
 
@@ -52,9 +24,11 @@ export const practiceQueriesService = {
   /**
    * List all practices (organizations) for the current user
    */
-  async listPractices(ctx: ServiceContext): Promise<{ practices: Organization[] }> {
-    const result = await organizationService.listOrganizations(ctx);
-    return { practices: result };
+  async listPractices(ctx: ServiceContext): Promise<{ practices: PracticeResponse[] }> {
+    const organizations = await organizationService.listOrganizations(ctx);
+    return {
+      practices: await loadPracticeResponsesForOrganizationIds(organizations.map((organization) => organization.id)),
+    };
   },
 
   /**
@@ -63,27 +37,14 @@ export const practiceQueriesService = {
   async getPracticeById(
     { organizationId }: OrganizationRequestParams,
     ctx: ServiceContext
-  ): Promise<{ practice: PracticeWithDetails }> {
+  ): Promise<{ practice: PracticeResponse }> {
     ForbiddenError.from(ctx.ability).throwUnlessCan('read', 'Organization');
 
     try {
-      const organization = await organizationRepository.findById(organizationId);
-      if (!organization) {
-        throw new HTTPException(404, { message: `Organization not found for '${organizationId}'` });
+      const practice = await loadPracticeResponseById(organizationId);
+      if (!practice) {
+        throw new HTTPException(404, { message: `Practice not found for '${organizationId}'` });
       }
-
-      // 2. Get optional practice details
-      const practiceDetails = await findPracticeDetailsByOrganization(organizationId);
-
-      // 3. Clean and combine data
-      const practice: PracticeWithDetails = {
-        ...practiceDetails,
-        ...organization,
-        metadata: parseBetterAuthMetadata(organization.metadata),
-        payment_link_enabled: organization.paymentLinkEnabled ?? null,
-        created_at: organization.createdAt,
-        updated_at: practiceDetails?.updated_at ?? undefined,
-      };
 
       return { practice };
     } catch (error) {
@@ -101,66 +62,16 @@ export const practiceQueriesService = {
   async getPracticeDetails(
     { organizationId }: OrganizationRequestParams,
     ctx: ServiceContext
-  ): Promise<PracticeDetailsResponse> {
+  ): Promise<PracticeResponse> {
     ForbiddenError.from(ctx.ability).throwUnlessCan('read', 'Organization');
 
     try {
-      // 1. Verify organization exists
-      const organization = await organizationRepository.findById(organizationId);
-      if (!organization) {
-        throw new HTTPException(404, { message: `Organization not found for '${organizationId}'` });
+      const practice = await loadPracticeResponseById(organizationId);
+      if (!practice) {
+        throw new HTTPException(404, { message: `Practice not found for '${organizationId}'` });
       }
 
-      // 2. Get practice details and services
-      const [fetchedDetails, services] = await Promise.all([
-        findPracticeDetailsByOrganization(organizationId),
-        practiceServicesRepository.findServicesByOrganization(organizationId),
-      ]);
-
-      if (!fetchedDetails) {
-        return {
-          id: null,
-          user_id: null,
-          address_id: null,
-          business_phone: null,
-          business_email: null,
-          consultation_fee: null,
-          payment_url: null,
-          calendly_url: null,
-          website: null,
-          intro_message: null,
-          overview: null,
-          accent_color: null,
-          is_public: false,
-          organization_id: organizationId,
-          services: [],
-          address: null,
-          name: organization.name,
-          logo: organization.logo ?? null,
-          payment_link_enabled: organization.paymentLinkEnabled ?? false,
-          billing_increment_minutes: 1,
-          created_at: null,
-          updated_at: undefined,
-          supported_states: null,
-          service_states: null,
-        };
-      }
-
-      // 3. Fetch address if linked
-      const addressData = await fetchAddressData(fetchedDetails.address_id);
-
-      // 4. Build response
-      const responseData: PracticeDetailsResponse = {
-        ...fetchedDetails,
-        organization_id: organizationId,
-        address: addressData,
-        services: services.map((s) => ({ id: s.id, name: s.name, key: s.key })),
-        name: organization.name,
-        logo: organization.logo ?? null,
-        payment_link_enabled: organization?.paymentLinkEnabled ?? false,
-      };
-
-      return responseData;
+      return practice;
     } catch (error) {
       if (error instanceof HTTPException) {
         throw error;
@@ -173,7 +84,7 @@ export const practiceQueriesService = {
   /**
    * Get practice details by slug (Public lookup)
    */
-  async getPracticeBySlug({ slug }: { slug: string }, _ctx: ServiceContext): Promise<PracticeDetailsResponse> {
+  async getPracticeBySlug({ slug }: { slug: string }, _ctx: ServiceContext): Promise<PracticeResponse> {
     try {
       // 1. Find organization by slug
       const slugResult = await organizationRepository.findBySlug(slug);
@@ -183,31 +94,12 @@ export const practiceQueriesService = {
       }
       const organization = slugResult;
 
-      // 2. Get practice details and services
-      const [fetchedDetails, services] = await Promise.all([
-        findPracticeDetailsByOrganization(organization.id),
-        practiceServicesRepository.findServicesByOrganization(organization.id),
-      ]);
-
-      if (!fetchedDetails || !fetchedDetails.is_public) {
+      const practice = await loadPracticeResponseById(organization.id);
+      if (!practice || !practice.is_public) {
         throw new HTTPException(404, { message: 'Practice not found' });
       }
 
-      // 3. Fetch address if linked
-      const addressData = await fetchAddressData(fetchedDetails.address_id);
-
-      // 4. Return data with organization details
-      const responseData: PracticeDetailsResponse = {
-        ...fetchedDetails,
-        organization_id: organization.id,
-        address: addressData,
-        services: services.map((s) => ({ id: s.id, name: s.name, key: s.key })),
-        name: organization.name ?? '',
-        logo: organization.logo ?? null,
-        payment_link_enabled: organization.paymentLinkEnabled ?? false,
-      };
-
-      return responseData;
+      return practice;
     } catch (error) {
       if (error instanceof HTTPException) {
         throw error;

--- a/src/modules/practice/services/practice-response.loader.ts
+++ b/src/modules/practice/services/practice-response.loader.ts
@@ -1,0 +1,83 @@
+import { findAddressesByIds } from '@/modules/practice/database/queries/address.repository';
+import { organizationRepository } from '@/modules/practice/database/queries/organization.repository';
+import { findPracticeDetailsByOrganizations } from '@/modules/practice/database/queries/practice-details.repository';
+import { practiceServicesRepository } from '@/modules/practice/database/queries/practice-services.repository';
+import type { PracticeDetails, PracticeService } from '@/modules/practice/database/schema/practice.schema';
+import { serializePractice } from '@/modules/practice/serializers/practice.serializer';
+import type { PracticeResponse } from '@/modules/practice/types/practice.types';
+import type { Address } from '@/shared/validations/address';
+
+const toResponseAddress = (address: Awaited<ReturnType<typeof findAddressesByIds>>[number]): Address => ({
+  line1: address.line1 ?? undefined,
+  line2: address.line2 ?? undefined,
+  city: address.city ?? undefined,
+  state: address.state ?? undefined,
+  postal_code: address.postal_code ?? undefined,
+  country: address.country ?? undefined,
+});
+
+const groupServicesByOrganization = (services: PracticeService[]): Map<string, PracticeService[]> => {
+  const servicesByOrganization = new Map<string, PracticeService[]>();
+
+  for (const service of services) {
+    const current = servicesByOrganization.get(service.organization_id) ?? [];
+    current.push(service);
+    servicesByOrganization.set(service.organization_id, current);
+  }
+
+  return servicesByOrganization;
+};
+
+export const loadPracticeResponsesForOrganizationIds = async (
+  organizationIds: string[]
+): Promise<PracticeResponse[]> => {
+  if (organizationIds.length === 0) {
+    return [];
+  }
+
+  const organizations = await organizationRepository.findByIds(organizationIds);
+  const organizationsById = new Map(organizations.map((organization) => [organization.id, organization]));
+  const orderedOrganizations = organizationIds
+    .map((organizationId) => organizationsById.get(organizationId))
+    .filter((organization): organization is NonNullable<typeof organization> => Boolean(organization));
+
+  const [details, services] = await Promise.all([
+    findPracticeDetailsByOrganizations(organizationIds),
+    practiceServicesRepository.findServicesByOrganizations(organizationIds),
+  ]);
+  const detailsByOrganization = new Map<string, PracticeDetails>(
+    details.map((practiceDetails) => [practiceDetails.organization_id, practiceDetails])
+  );
+  const addressIds = details
+    .map((practiceDetails) => practiceDetails.address_id)
+    .filter((addressId): addressId is string => addressId !== null);
+  const addresses = await findAddressesByIds(addressIds);
+  const addressesById = new Map(addresses.map((address) => [address.id, toResponseAddress(address)]));
+  const servicesByOrganization = groupServicesByOrganization(services);
+
+  return orderedOrganizations.flatMap((organization) => {
+    const practiceDetails = detailsByOrganization.get(organization.id);
+    if (!practiceDetails) {
+      return [];
+    }
+    const address = practiceDetails.address_id ? (addressesById.get(practiceDetails.address_id) ?? null) : null;
+
+    return [
+      serializePractice({
+        organization,
+        details: practiceDetails,
+        services: (servicesByOrganization.get(organization.id) ?? []).map((service) => ({
+          id: service.id,
+          name: service.name,
+          key: service.key,
+        })),
+        address,
+      }),
+    ];
+  });
+};
+
+export const loadPracticeResponseById = async (organizationId: string): Promise<PracticeResponse | null> => {
+  const [practice] = await loadPracticeResponsesForOrganizationIds([organizationId]);
+  return practice ?? null;
+};

--- a/src/modules/practice/types/practice.types.ts
+++ b/src/modules/practice/types/practice.types.ts
@@ -36,18 +36,8 @@ export type OrganizationApiShape = Organization & {
   updatedAt?: Date | null;
 };
 
-type OrganizationWithoutCamelCase = Omit<OrganizationApiShape, 'paymentLinkEnabled' | 'createdAt' | 'updatedAt'>;
-
-export type NormalizedOrganization = OrganizationWithoutCamelCase & {
-  payment_link_enabled: boolean | null;
-  created_at: Date;
-  updated_at: Date | undefined;
-};
-
-export type PracticeWithDetails = NormalizedOrganization & Partial<PracticeDetails>;
-
 export interface PracticeWithUser {
-  practice: NormalizedOrganization;
+  practice: PracticeResponse;
   user: User;
   practice_details: Partial<PracticeDetails> | null;
 }
@@ -70,6 +60,6 @@ export type UpdatePracticeDetailsRequest = z.infer<typeof practiceValidations.up
 
 export type PracticeResponse = z.infer<typeof practiceValidations.practiceResponseSchema>;
 export type PracticeListResponse = z.infer<typeof practiceValidations.practiceListResponseSchema>;
-export type PracticeDetailsResponse = z.infer<typeof practiceValidations.practiceDetailsResponseSchema>;
+export type PracticeDetailsResponse = PracticeResponse;
 export type MemberListItem = z.infer<typeof practiceValidations.memberListItemSchema>;
 export type InvitationListItem = z.infer<typeof practiceValidations.invitationListItemSchema>;

--- a/src/modules/practice/validations/practice.validation.ts
+++ b/src/modules/practice/validations/practice.validation.ts
@@ -151,7 +151,7 @@ const updatePracticeSchema = updatePracticeSchemaBase.refine(
 const practiceResponseSchema = z
   .object({
     id: z.uuid().openapi({
-      description: 'Organization ID (UUID)',
+      description: 'Organization ID (the canonical practice identifier)',
       example: '123e4567-e89b-12d3-a456-426614174000',
     }),
     name: z.string().openapi({
@@ -163,12 +163,6 @@ const practiceResponseSchema = z
     logo: z.string().nullable().openapi({
       example: 'https://example.com/logo.png',
     }),
-    metadata: z
-      .record(z.string(), z.unknown())
-      .nullable()
-      .openapi({
-        example: { key: 'value' },
-      }),
     business_phone: z.string().nullable().openapi({
       description: 'Business phone number',
       example: '+1234567890',
@@ -217,15 +211,27 @@ const practiceResponseSchema = z
       description: 'Billing increment in minutes for time entry dropdowns',
       example: 15,
     }),
-    created_at: z.date().openapi({
-      format: 'date-time',
-      description: 'Organization creation timestamp',
-      example: '2024-01-01T00:00:00Z',
+    services: z
+      .array(z.object({ id: z.string(), name: z.string(), key: z.string() }))
+      .openapi({ example: [{ id: '1', name: 'Service 1', key: 'SERVICE_1' }] }),
+    service_states: z
+      .array(z.string())
+      .nullable()
+      .openapi({ example: ['NC', 'SC'] }),
+    supported_states: z
+      .array(supportedStatesItemSchema)
+      .nullable()
+      .openapi({ example: [{ country: 'US', states: ['NY', 'NJ'] }] }),
+    address: addressSchema.nullable().openapi({
+      example: { line1: '123 Main St', city: 'Austin', state: 'TX', postal_code: '78701', country: 'US' },
     }),
-    updated_at: z.date().optional().openapi({
-      format: 'date-time',
-      description: 'Organization last update timestamp',
-      example: '2024-01-01T00:00:00Z',
+    created_at: z.string().datetime().openapi({
+      description: 'Organization creation timestamp (ISO 8601)',
+      example: '2024-01-01T00:00:00.000Z',
+    }),
+    updated_at: z.string().datetime().openapi({
+      description: 'Latest organization or practice details update timestamp (ISO 8601)',
+      example: '2024-01-01T00:00:00.000Z',
     }),
   })
   .openapi('PracticeResponse');
@@ -414,111 +420,10 @@ const createPracticeDetailsSchema = practiceDetailsValidationSchema.refine(
 
 const updatePracticeDetailsSchema = practiceDetailsValidationSchema;
 
-const practiceDetailsResponseSchema = z
-  .object({
-    id: z.uuid().nullable().openapi({
-      description: 'Practice Details ID',
-      example: '123e4567-e89b-12d3-a456-426614174000',
-    }),
-    user_id: z.uuid().nullable().openapi({
-      description: 'User ID of the creator',
-      example: '123e4567-e89b-12d3-a456-426614174000',
-    }),
-    address_id: z.uuid().nullable().openapi({
-      description: 'Linked Address ID',
-      example: '123e4567-e89b-12d3-a456-426614174000',
-    }),
-    business_phone: z.string().nullable().openapi({
-      example: '+1234567890',
-    }),
-    business_email: z.email().nullable().openapi({
-      example: 'contact@example.com',
-    }),
-    consultation_fee: z.number().nullable().openapi({
-      example: 100.0,
-    }),
-    payment_url: z.url().nullable().openapi({
-      example: 'https://payment.example.com',
-    }),
-    calendly_url: z.url().nullable().openapi({
-      example: 'https://calendly.com/example',
-    }),
-    website: z.string().nullable().openapi({ example: 'https://example.com' }),
-    intro_message: z.string().nullable().openapi({ example: 'Welcome' }),
-    overview: z.string().nullable().openapi({ example: 'Overview text' }),
-    accent_color: z.string().nullable().openapi({ example: '#3B82F6' }),
-    is_public: z.boolean().openapi({ example: true }),
-    organization_id: z.uuid().openapi({
-      description: 'Organization UUID for the practice',
-      example: '9f7a2c1f-8e5c-4b8a-9d7f-1234567890ab',
-    }),
-    services: z
-      .array(z.object({ id: z.string(), name: z.string(), key: z.string() }))
-      .nullable()
-      .openapi({ example: [{ id: '1', name: 'Service 1', key: 'SERVICE_1' }] }),
-    address: addressSchema.nullable().openapi({
-      description: 'Practice or organizational address',
-      example: {
-        line1: '123 Business Way',
-        city: 'San Francisco',
-        state: 'CA',
-        postal_code: '94105',
-        country: 'US',
-      },
-    }),
-    name: z.string().openapi({
-      example: 'My Practice',
-    }),
-    logo: z.url().nullable().openapi({
-      example: 'https://example.com/logo.png',
-    }),
-    payment_link_enabled: z.boolean().openapi({
-      example: true,
-    }),
-    billing_increment_minutes: billingIncrementMinutesSchema.openapi({
-      description: 'Billing increment in minutes for time entry dropdowns',
-      example: 15,
-    }),
-    created_at: z.date().nullable().openapi({
-      description: 'Practice details creation timestamp',
-      format: 'date-time',
-      example: '2024-01-01T00:00:00Z',
-    }),
-    updated_at: z.date().optional().openapi({
-      format: 'date-time',
-      description: 'Practice details last update timestamp',
-      example: '2024-01-01T00:00:00Z',
-    }),
-    supported_states: z
-      .array(
-        z.object({
-          country: z.string().openapi({ example: 'US' }),
-          states: z
-            .array(z.string())
-            .optional()
-            .openapi({ example: ['NY', 'NJ'] }),
-        })
-      )
-      .nullable()
-      .openapi({
-        description: 'List of supported countries and states',
-        example: [{ country: 'US', states: ['NY', 'NJ'] }, { country: 'CA', states: ['ON'] }, { country: 'GB' }],
-      }),
-    service_states: z
-      .array(z.string())
-      .nullable()
-      .openapi({
-        description: 'US states where the practice is licensed to practice (2-letter codes)',
-        example: ['NC', 'SC', 'VA'],
-      }),
-  })
-  .openapi('PracticeDetailsResponse');
-
-const practiceDetailsSingleResponseSchema = practiceDetailsResponseSchema;
-
-const practiceDetailsCreateResponseSchema = practiceDetailsResponseSchema;
-
-const practiceDetailsUpdateResponseSchema = practiceDetailsResponseSchema;
+const practiceDetailsResponseSchema = practiceResponseSchema;
+const practiceDetailsSingleResponseSchema = practiceResponseSchema;
+const practiceDetailsCreateResponseSchema = practiceResponseSchema;
+const practiceDetailsUpdateResponseSchema = practiceResponseSchema;
 
 const slugParamSchema = z.object({
   slug: z.string(),

--- a/test/modules/practice/practice.test.ts
+++ b/test/modules/practice/practice.test.ts
@@ -1,0 +1,325 @@
+import { randomUUID } from 'node:crypto';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { addresses } from '@/modules/practice/database/schema/addresses.schema';
+import { practiceDetails, practiceServices } from '@/modules/practice/database/schema/practice.schema';
+import practiceApp from '@/modules/practice/http';
+import type { PracticeResponse } from '@/modules/practice/types/practice.types';
+import { organizations } from '@/schema/better-auth-schema';
+import {
+  PracticeCreated,
+  PracticeDetailsCreated,
+  PracticeDetailsUpdated,
+  PracticeUpdated,
+} from '@/shared/events/definitions';
+import { requireAuth } from '@/shared/middleware/requireAuth';
+import { requireOrgMembership } from '@/shared/middleware/requireOrgMembership';
+import { authHelpers } from '@/test/helpers/auth';
+import { getTestDb } from '@/test/helpers/db';
+import { createAuthenticatedRequest, createRequest } from '@/test/helpers/request';
+import type { TestOrganization } from '@/test/types/shared';
+
+const canonicalPracticeKeys = [
+  'id',
+  'slug',
+  'name',
+  'logo',
+  'business_phone',
+  'business_email',
+  'website',
+  'consultation_fee',
+  'payment_url',
+  'calendly_url',
+  'intro_message',
+  'overview',
+  'accent_color',
+  'is_public',
+  'billing_increment_minutes',
+  'payment_link_enabled',
+  'services',
+  'service_states',
+  'supported_states',
+  'address',
+  'created_at',
+  'updated_at',
+].sort();
+
+const authOnlyApp = new Hono();
+authOnlyApp.use('/api/*', requireAuth());
+authOnlyApp.route('/api/practice', practiceApp);
+
+const protectedApp = new Hono();
+protectedApp.use('/api/*', requireAuth());
+protectedApp.use('/api/*', requireOrgMembership());
+protectedApp.route('/api/practice', practiceApp);
+
+const publicApp = new Hono();
+publicApp.route('/api/practice', practiceApp);
+
+const publicRequest = createRequest(publicApp.fetch);
+
+const expectCanonicalPractice = (practice: PracticeResponse, expectedOrganizationId: string): void => {
+  expect(Object.keys(practice).sort()).toEqual(canonicalPracticeKeys);
+  expect(practice.id).toBe(expectedOrganizationId);
+  expect(practice.created_at).toEqual(expect.any(String));
+  expect(practice.updated_at).toEqual(expect.any(String));
+  expect(new Date(practice.created_at).toISOString()).toBe(practice.created_at);
+  expect(new Date(practice.updated_at).toISOString()).toBe(practice.updated_at);
+  expect(practice).not.toHaveProperty('createdAt');
+  expect(practice).not.toHaveProperty('updatedAt');
+  expect(practice).not.toHaveProperty('stripeCustomerId');
+  expect(practice).not.toHaveProperty('stripePaymentMethodId');
+  expect(practice).not.toHaveProperty('metadata');
+  expect(practice).not.toHaveProperty('organization_id');
+  expect(practice).not.toHaveProperty('user_id');
+  expect(practice).not.toHaveProperty('address_id');
+};
+
+describe('Practice API response contract', () => {
+  const db = getTestDb();
+  let org: TestOrganization;
+  let sessionToken = '';
+  let userId = '';
+  let serviceId = '';
+
+  beforeAll(async () => {
+    vi.spyOn(PracticeCreated, 'dispatch').mockResolvedValue('test-event-id');
+    vi.spyOn(PracticeUpdated, 'dispatch').mockResolvedValue('test-event-id');
+    vi.spyOn(PracticeDetailsCreated, 'dispatch').mockResolvedValue('test-event-id');
+    vi.spyOn(PracticeDetailsUpdated, 'dispatch').mockResolvedValue('test-event-id');
+
+    const context = await authHelpers.createTestContext('owner');
+    org = context.org;
+    sessionToken = context.sessionToken;
+    userId = context.session!.user.id;
+
+    const [address] = await db
+      .insert(addresses)
+      .values({
+        organization_id: org.id,
+        type: 'practice_location',
+        line1: '123 Main St',
+        city: 'Raleigh',
+        state: 'NC',
+        postal_code: '27601',
+        country: 'US',
+      })
+      .returning();
+
+    await db
+      .update(organizations)
+      .set({
+        metadata: JSON.stringify({ theme: 'blue' }),
+        paymentLinkEnabled: true,
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      })
+      .where(eq(organizations.id, org.id));
+
+    await db.insert(practiceDetails).values({
+      organization_id: org.id,
+      user_id: userId,
+      address_id: address.id,
+      business_phone: '+12025550101',
+      business_email: 'office@example.com',
+      website: 'https://example.com',
+      overview: 'Family law practice',
+      accent_color: '#3B82F6',
+      is_public: true,
+      billing_increment_minutes: 15,
+      service_states: ['NC'],
+      supported_states: [{ country: 'US', states: ['NC'] }],
+      updated_at: new Date('2026-01-02T00:00:00.000Z'),
+    });
+
+    const [service] = await db
+      .insert(practiceServices)
+      .values({ organization_id: org.id, name: 'Consultation', key: 'CONSULTATION' })
+      .returning();
+    serviceId = service.id;
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the canonical configured resource from all read endpoints', async () => {
+    const authRequest = createAuthenticatedRequest(authOnlyApp.fetch, sessionToken);
+    const memberRequest = createAuthenticatedRequest(protectedApp.fetch, sessionToken);
+
+    const [listRes, byIdRes, detailsRes, slugRes] = await Promise.all([
+      authRequest.get('/api/practice/list'),
+      memberRequest.get(`/api/practice/${org.id}`),
+      memberRequest.get(`/api/practice/${org.id}/details`),
+      publicRequest.get(`/api/practice/details/${org.slug}`),
+    ]);
+
+    expect(listRes.status).toBe(200);
+    expect(byIdRes.status).toBe(200);
+    expect(detailsRes.status).toBe(200);
+    expect(slugRes.status).toBe(200);
+
+    const practices: PracticeResponse[] = [
+      (listRes.body.practices as PracticeResponse[]).find((practice) => practice.id === org.id)!,
+      byIdRes.body.practice as PracticeResponse,
+      detailsRes.body as PracticeResponse,
+      slugRes.body as PracticeResponse,
+    ];
+
+    for (const practice of practices) {
+      expectCanonicalPractice(practice, org.id);
+      expect(practice).toMatchObject({
+        business_phone: '+12025550101',
+        accent_color: '#3B82F6',
+        services: [{ id: serviceId, name: 'Consultation', key: 'CONSULTATION' }],
+        address: { city: 'Raleigh', state: 'NC' },
+        updated_at: '2026-01-02T00:00:00.000Z',
+      });
+    }
+  });
+
+  it('does not synthesize practice defaults for an organization without stored details', async () => {
+    const context = await authHelpers.createTestContext('owner');
+    const memberRequest = createAuthenticatedRequest(protectedApp.fetch, context.sessionToken);
+    const res = await memberRequest.get(`/api/practice/${context.org.id}/details`);
+
+    expect(res.status, JSON.stringify(res.body)).toBe(404);
+  });
+
+  it('returns database-backed defaults when creating a minimal practice', async () => {
+    const context = await authHelpers.createTestContext('owner');
+    const authRequest = createAuthenticatedRequest(authOnlyApp.fetch, context.sessionToken);
+    const slug = `minimal-${randomUUID().slice(0, 20)}`;
+    const res = await authRequest.post('/api/practice').send({
+      name: 'Minimal Practice',
+      slug,
+    });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    const practice = res.body.practice as PracticeResponse;
+    const [storedDetails] = await db
+      .select()
+      .from(practiceDetails)
+      .where(eq(practiceDetails.organization_id, practice.id));
+    const [storedOrganization] = await db.select().from(organizations).where(eq(organizations.id, practice.id));
+
+    if (!storedDetails || !storedOrganization) {
+      throw new Error('Minimal practice create must persist organization and practice details rows');
+    }
+
+    expect(storedDetails).toMatchObject({ is_public: false, billing_increment_minutes: 1 });
+    expect(storedOrganization.paymentLinkEnabled).toBe(false);
+    expectCanonicalPractice(practice, practice.id);
+    expect(practice).toMatchObject({
+      business_phone: storedDetails.business_phone,
+      accent_color: storedDetails.accent_color,
+      is_public: storedDetails.is_public,
+      billing_increment_minutes: storedDetails.billing_increment_minutes,
+      payment_link_enabled: storedOrganization.paymentLinkEnabled,
+      services: [],
+      supported_states: storedDetails.supported_states,
+      service_states: storedDetails.service_states,
+      address: null,
+    });
+  });
+
+  it('returns the canonical post-write state when creating a practice', async () => {
+    const context = await authHelpers.createTestContext('owner');
+    const authRequest = createAuthenticatedRequest(authOnlyApp.fetch, context.sessionToken);
+    const slug = `created-${randomUUID().slice(0, 20)}`;
+    const res = await authRequest.post('/api/practice').send({
+      name: 'Created Contract Practice',
+      slug,
+      overview: 'Created through API',
+      is_public: true,
+      services: [{ name: 'Advisory', key: 'ADVISORY' }],
+      address: { city: 'Durham', state: 'NC', country: 'US' },
+    });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    const practice = res.body.practice as PracticeResponse;
+    expectCanonicalPractice(practice, practice.id);
+    expect(practice).toMatchObject({
+      slug,
+      overview: 'Created through API',
+      services: [{ name: 'Advisory', key: 'ADVISORY' }],
+      address: { city: 'Durham', state: 'NC', country: 'US' },
+    });
+  });
+
+  it('returns the canonical post-write state when creating details', async () => {
+    const context = await authHelpers.createTestContext('owner');
+    const memberRequest = createAuthenticatedRequest(protectedApp.fetch, context.sessionToken);
+    const res = await memberRequest.post(`/api/practice/${context.org.id}/details`).send({
+      overview: 'New details record',
+      services: [{ name: 'Review', key: 'REVIEW' }],
+      address: { city: 'Charlotte', state: 'NC', country: 'US' },
+    });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    const practice = res.body as PracticeResponse;
+    expectCanonicalPractice(practice, context.org.id);
+    expect(practice).toMatchObject({
+      overview: 'New details record',
+      services: [{ name: 'Review', key: 'REVIEW' }],
+      address: { city: 'Charlotte', state: 'NC', country: 'US' },
+    });
+  });
+
+  it('preserves nested state after a partial unified update and details update', async () => {
+    const memberRequest = createAuthenticatedRequest(protectedApp.fetch, sessionToken);
+    const unifiedRes = await memberRequest.put(`/api/practice/${org.id}`).send({ overview: 'Updated overview' });
+    expect(unifiedRes.status, JSON.stringify(unifiedRes.body)).toBe(200);
+
+    const unifiedPractice = unifiedRes.body.practice as PracticeResponse;
+    expectCanonicalPractice(unifiedPractice, org.id);
+    expect(unifiedPractice.overview).toBe('Updated overview');
+    expect(unifiedPractice.services).toEqual([{ id: serviceId, name: 'Consultation', key: 'CONSULTATION' }]);
+    expect(unifiedPractice.address).toMatchObject({ city: 'Raleigh', state: 'NC' });
+
+    const detailsRes = await memberRequest
+      .put(`/api/practice/${org.id}/details`)
+      .send({ overview: 'Updated through details' });
+    expect(detailsRes.status, JSON.stringify(detailsRes.body)).toBe(200);
+
+    const detailsPractice = detailsRes.body as PracticeResponse;
+    expectCanonicalPractice(detailsPractice, org.id);
+    expect(detailsPractice.overview).toBe('Updated through details');
+    expect(detailsPractice.services).toEqual([{ id: serviceId, name: 'Consultation', key: 'CONSULTATION' }]);
+    expect(detailsPractice.address).toMatchObject({ city: 'Raleigh', state: 'NC' });
+  });
+
+  it('does not expose stored organization metadata', async () => {
+    await db
+      .update(organizations)
+      .set({ metadata: JSON.stringify({ internal: 'do-not-return' }) })
+      .where(eq(organizations.id, org.id));
+    const memberRequest = createAuthenticatedRequest(protectedApp.fetch, sessionToken);
+    const res = await memberRequest.get(`/api/practice/${org.id}/details`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).not.toHaveProperty('metadata');
+  });
+
+  it('uses organization updatedAt when it is later than the details update', async () => {
+    await db
+      .update(practiceDetails)
+      .set({ updated_at: new Date('2026-01-02T00:00:00.000Z') })
+      .where(eq(practiceDetails.organization_id, org.id));
+    await db
+      .update(organizations)
+      .set({ updatedAt: new Date('2026-01-03T00:00:00.000Z') })
+      .where(eq(organizations.id, org.id));
+    const memberRequest = createAuthenticatedRequest(protectedApp.fetch, sessionToken);
+    const res = await memberRequest.get(`/api/practice/${org.id}/details`);
+
+    expect(res.status).toBe(200);
+    expect((res.body as PracticeResponse).updated_at).toBe('2026-01-03T00:00:00.000Z');
+  });
+
+  it('does not expose a practice through slug lookup unless it is public', async () => {
+    await db.update(practiceDetails).set({ is_public: false }).where(eq(practiceDetails.organization_id, org.id));
+    const res = await publicRequest.get(`/api/practice/details/${org.slug}`);
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
- Added `findByIds` method to `organization.repository.ts` for bulk fetching organizations by IDs.
- Introduced `findPracticeDetailsByOrganizations` in `practice-details.repository.ts` for fetching practice details by multiple organization IDs.
- Implemented `findServicesByOrganizations` in `practice-services.repository.ts` to retrieve services for multiple organizations.
- Created `practice.serializer.ts` for serializing practice data into a consistent response format.
- Updated `practice-details-management.service.ts` to utilize the new loading methods for practice responses.
- Refactored `practice-management.service.ts` to load practice details using the new loader functions.
- Enhanced `practice-queries.service.ts` to return practice responses instead of raw data.
- Added `practice-response.loader.ts` to handle the loading and serialization of practice data.
- Updated validation schemas in `practice.validation.ts` to align with the new response structure.
- Created comprehensive tests in `practice.test.ts` to ensure the correctness of the new features and endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch query helpers for efficient multi-record lookups across address, organization, practice details, and services repositories.
  * Introduced centralized practice response loader for consistent data serialization.

* **Refactor**
  * Unified all practice API endpoints to return a consistent `PracticeResponse` format.
  * Changed timestamp fields (`created_at`, `updated_at`) from date objects to ISO-8601 strings for consistency.
  * Removed automatic default synthesis for missing practice details; endpoints now return 404 when details don't exist.
  * Simplified response schemas across list, get, create, and update endpoints.

* **Tests**
  * Added comprehensive test suite validating practice API response contracts and endpoint behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Blawby/blawby-backend/pull/300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->