### PR TITLE
Add fast matter activity count endpoint

### DIFF
--- a/src/modules/matters/database/schema/matter-activity-log.schema.ts
+++ b/src/modules/matters/database/schema/matter-activity-log.schema.ts
@@ -22,6 +22,7 @@ export const matterActivityLog = pgTable(
   },
   (table) => [
     index('matter_activity_log_matter_idx').on(table.matter_id),
+    index('matter_activity_log_matter_created_at_idx').on(table.matter_id, table.created_at),
     index('matter_activity_log_user_idx').on(table.user_id),
     index('matter_activity_log_action_idx').on(table.action),
     index('matter_activity_log_created_at_idx').on(table.created_at),

--- a/src/modules/matters/handlers.ts
+++ b/src/modules/matters/handlers.ts
@@ -84,6 +84,15 @@ const getMatterActivityHandler: AppRouteHandler<typeof matterRoutes.getMatterAct
   return c.json({ activities }, 200);
 };
 
+const getMatterActivityCountHandler: AppRouteHandler<typeof matterRoutes.getMatterActivityCountRoute> = async (c) => {
+  const ctx = getServiceContext(c);
+  const { matter_id: matterId } = c.req.valid('param');
+  const scopedCtx = { ...ctx, matterId };
+  const query = c.req.valid('query');
+  const count = await matterActivityService.getMatterActivityCount({ since: query.since }, scopedCtx);
+  return c.json({ count }, 200);
+};
+
 const listMatterNotesHandler: AppRouteHandler<typeof matterRoutes.listMatterNotesRoute> = async (c) => {
   const ctx = getServiceContext(c);
   const { matter_id: matterId } = c.req.valid('param');
@@ -415,6 +424,7 @@ export const handlers = {
   updateTimeEntryHandler,
   deleteTimeEntryHandler,
   getMatterActivityHandler,
+  getMatterActivityCountHandler,
   getTimeEntryStatsHandler,
   listExpensesHandler,
   createExpenseHandler,

--- a/src/modules/matters/http.ts
+++ b/src/modules/matters/http.ts
@@ -38,6 +38,7 @@ matterSubResources.use('/:id/*', requireMatterAccess());
 
 // Activity
 matterSubResources.openapi(matterRoutes.getMatterActivityRoute, matterHandlers.getMatterActivityHandler);
+matterSubResources.openapi(matterRoutes.getMatterActivityCountRoute, matterHandlers.getMatterActivityCountHandler);
 
 // Tasks
 matterSubResources.openapi(matterRoutes.listMatterTasksRoute, matterHandlers.listMatterTasksHandler);

--- a/src/modules/matters/routes/activity.routes.ts
+++ b/src/modules/matters/routes/activity.routes.ts
@@ -1,5 +1,5 @@
 import { z } from '@hono/zod-openapi';
-import { getActivityLogQuerySchema } from '@/modules/matters/types/matter.types';
+import { getActivityCountQuerySchema, getActivityLogQuerySchema } from '@/modules/matters/types/matter.types';
 import { routeBuilder } from '@/shared/router/route-builder';
 
 const tags = ['Matters'];
@@ -22,6 +22,31 @@ export const getMatterActivityRoute = routeBuilder.build({
         'application/json': {
           schema: z.object({
             activities: z.array(z.any()), // Activity schema is complex/dynamic in original code.
+          }),
+        },
+      },
+    },
+  },
+});
+
+export const getMatterActivityCountRoute = routeBuilder.build({
+  method: 'get',
+  path: '/{matter_id}/activity/count',
+  tags,
+  summary: 'Get matter activity count since a timestamp',
+  request: {
+    params: z.object({
+      matter_id: z.uuid(),
+    }),
+    query: getActivityCountQuerySchema,
+  },
+  responses: {
+    200: {
+      description: 'Activity count retrieved successfully',
+      content: {
+        'application/json': {
+          schema: z.object({
+            count: z.number().int().nonnegative(),
           }),
         },
       },

--- a/src/modules/matters/routes/index.ts
+++ b/src/modules/matters/routes/index.ts
@@ -1,4 +1,4 @@
-import { getMatterActivityRoute } from './activity.routes';
+import { getMatterActivityCountRoute, getMatterActivityRoute } from './activity.routes';
 import {
   createMatterRoute,
   listMattersRoute,
@@ -57,6 +57,7 @@ export const routes = {
   deleteMatterRoute,
   getMattersSummaryByOriginatingAttorneyRoute,
   getMatterActivityRoute,
+  getMatterActivityCountRoute,
   getTimeEntryStatsRoute,
   listTimeEntriesRoute,
   createTimeEntryRoute,

--- a/src/modules/matters/services/matter-activity.service.ts
+++ b/src/modules/matters/services/matter-activity.service.ts
@@ -5,7 +5,7 @@
  */
 
 import { getLogger } from '@logtape/logtape';
-import { eq, desc, and } from 'drizzle-orm';
+import { eq, desc, and, gte, count } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { HTTPException } from 'hono/http-exception';
 import {
@@ -96,6 +96,23 @@ const getMatterActivity = async (
     .offset(offset);
 };
 
+const getMatterActivityCount = async (options: { since: Date }, ctx: ServiceContext): Promise<number> => {
+  const { matterId } = ctx;
+  if (!matterId) {
+    throw new HTTPException(400, { message: 'Matter ID not found in context' });
+  }
+
+  const { mattersService } = await import('@/modules/matters/services/matters.service');
+  await mattersService.verifyMatterAccess(matterId, ctx);
+
+  const [result] = await db
+    .select({ count: count() })
+    .from(matterActivityLog)
+    .where(and(eq(matterActivityLog.matter_id, matterId), gte(matterActivityLog.created_at, options.since)));
+
+  return result?.count ?? 0;
+};
+
 /**
  * Activity action types
  */
@@ -132,5 +149,6 @@ const ActivityAction = {
 export const matterActivityService = {
   logMatterActivity,
   getMatterActivity,
+  getMatterActivityCount,
   ActivityAction,
 };

--- a/src/modules/matters/types/matter-filters.types.ts
+++ b/src/modules/matters/types/matter-filters.types.ts
@@ -67,4 +67,5 @@ export interface MatterActivityListFilters {
   limit?: number;
   offset?: number;
   activityId?: string;
+  since?: Date;
 }

--- a/src/modules/matters/types/matter.types.ts
+++ b/src/modules/matters/types/matter.types.ts
@@ -23,6 +23,7 @@ export const matterExpenseResponseSchema = matterExpenseValidations.expenseSchem
 export const listMatterExpensesQuerySchema = matterExpenseValidations.listExpensesQuerySchema;
 
 export const { getActivityLogQuerySchema } = matterValidations;
+export const { getActivityCountQuerySchema } = matterValidations;
 
 export const createMatterMilestoneRequestSchema = matterMilestoneValidations.createMatterMilestoneSchema;
 export const updateMatterMilestoneRequestSchema = matterMilestoneValidations.updateMatterMilestoneSchema;

--- a/src/modules/matters/validations/matters.validation.ts
+++ b/src/modules/matters/validations/matters.validation.ts
@@ -149,6 +149,10 @@ const getActivityLogQuerySchema = z.object({
   offset: z.coerce.number().int().min(0).default(0),
 });
 
+const getActivityCountQuerySchema = z.object({
+  since: z.coerce.date(),
+});
+
 const matterSchema = z
   .object({
     id: z.uuid(),
@@ -216,6 +220,7 @@ export const matterValidations = {
   matterIdParamSchema,
   listMattersQuerySchema,
   getActivityLogQuerySchema,
+  getActivityCountQuerySchema,
   matterSchema,
   activityLogSchema,
 };

--- a/src/shared/database/migrations/0059_activity_count_index.sql
+++ b/src/shared/database/migrations/0059_activity_count_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS "matter_activity_log_matter_created_at_idx"
+  ON "matter_activity_log" USING btree ("matter_id", "created_at");


### PR DESCRIPTION
## Summary
- add `GET /api/matters/{practice_id}/{matter_id}/activity/count?since=<ISO timestamp>`
- implement a dedicated `COUNT(*)` query in `matterActivityService` filtered by `matter_id` and `created_at >= since`
- wire route + handler + validation schema for `since`
- add composite DB index `matter_activity_log(matter_id, created_at)` via migration `0059_activity_count_index.sql`

## Notes
- This keeps existing activity listing behavior unchanged and provides an efficient count-only path.

Closes #310


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to retrieve the count of matter activity entries.
  * Activity count queries support an optional date filter to retrieve activities since a specific date.
  * Database optimizations implemented to improve query performance for activity counting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->