### PR TITLE
chore: remove service_states, consolidate on supported_states

### DIFF
--- a/src/modules/practice/database/schema/practice.schema.ts
+++ b/src/modules/practice/database/schema/practice.schema.ts
@@ -31,7 +31,6 @@ export const practiceDetails = pgTable('practice_details', {
   created_at: timestamp('created_at', { withTimezone: true, mode: 'date' }).defaultNow().notNull(),
   updated_at: timestamp('updated_at', { withTimezone: true, mode: 'date' }).defaultNow().notNull(),
   supported_states: jsonb('supported_states').$type<PracticeDetailsSupportedStates[]>(),
-  service_states: jsonb('service_states').$type<string[]>(),
 });
 
 // Practice services table (normalized)

--- a/src/modules/practice/serializers/practice.serializer.ts
+++ b/src/modules/practice/serializers/practice.serializer.ts
@@ -47,7 +47,6 @@ export const serializePractice = ({
   billing_increment_minutes: details.billing_increment_minutes,
   payment_link_enabled: organization.paymentLinkEnabled,
   services,
-  service_states: details.service_states,
   supported_states: details.supported_states,
   address,
   created_at: organization.createdAt.toISOString(),

--- a/src/modules/practice/services/conflict-check.service.ts
+++ b/src/modules/practice/services/conflict-check.service.ts
@@ -54,12 +54,9 @@ const buildWarnings = async (organizationId: string, input: ConflictCheckInput):
   if (input.state) {
     const state = input.state.toUpperCase();
     const supported = details.supported_states ?? [];
-    const serviceStates = details.service_states ?? [];
-
     const inSupportedStates = supported.some((entry) => !entry.states || entry.states.includes(state));
-    const inServiceStates = serviceStates.includes(state);
 
-    if (!inSupportedStates && !inServiceStates) {
+    if (!inSupportedStates) {
       warnings.push({
         type: 'unsupported_state',
         message: `Practice does not serve clients in ${state}.`,

--- a/src/modules/practice/services/practice-management.helpers.ts
+++ b/src/modules/practice/services/practice-management.helpers.ts
@@ -27,7 +27,6 @@ export const DETAILS_FIELD_KEYS: DetailsFieldKeys[] = [
   'is_public',
   'services',
   'supported_states',
-  'service_states',
   'address',
   'accent_color',
 ];
@@ -68,7 +67,6 @@ export const upsertDetailsTransaction = async (ctx: ServiceContext, params: Upse
     is_public: params.data.is_public ?? undefined,
     accent_color: params.data.accent_color ?? undefined,
     supported_states: params.data.supported_states ?? undefined,
-    service_states: params.data.service_states ?? undefined,
   };
 
   const updatePayload = { address_id: addressId, ...detailsPayload, updated_at: new Date() };

--- a/src/modules/practice/types/practice-details.types.ts
+++ b/src/modules/practice/types/practice-details.types.ts
@@ -21,7 +21,6 @@ export interface UpsertPracticeDetailsRequest {
   billing_increment_minutes?: number;
   services?: { id?: string; name: string; key: string }[];
   supported_states?: PracticeDetailsSupportedStates[];
-  service_states?: string[];
   // Nested Address fields
   address?: AddressData;
 }

--- a/src/modules/practice/types/practice-management.types.ts
+++ b/src/modules/practice/types/practice-management.types.ts
@@ -21,7 +21,6 @@ export type DetailsData = Partial<
     | 'accent_color'
     | 'services'
     | 'supported_states'
-    | 'service_states'
     | 'address'
   >
 >;
@@ -41,7 +40,6 @@ export type DetailsFieldKeys =
   | 'is_public'
   | 'services'
   | 'supported_states'
-  | 'service_states'
   | 'address'
   | 'accent_color';
 

--- a/src/modules/practice/validations/practice.validation.ts
+++ b/src/modules/practice/validations/practice.validation.ts
@@ -73,21 +73,6 @@ const practiceDetailsValidationSchema = z.object({
       description: 'List of supported countries and states',
       example: [{ country: 'US', states: ['NY', 'NJ'] }, { country: 'CA', states: ['ON'] }, { country: 'GB' }],
     }),
-  service_states: z
-    .array(
-      z
-        .string()
-        .length(2)
-        .regex(/^[A-Z]{2}$/)
-    )
-    .optional()
-    .refine((items) => !items || new Set(items).size === items.length, {
-      message: 'State codes must be unique',
-    })
-    .openapi({
-      description: 'US states where the practice is licensed to practice (2-letter codes)',
-      example: ['NC', 'SC', 'VA'],
-    }),
 });
 
 /**
@@ -214,10 +199,6 @@ const practiceResponseSchema = z
     services: z
       .array(z.object({ id: z.string(), name: z.string(), key: z.string() }))
       .openapi({ example: [{ id: '1', name: 'Service 1', key: 'SERVICE_1' }] }),
-    service_states: z
-      .array(z.string())
-      .nullable()
-      .openapi({ example: ['NC', 'SC'] }),
     supported_states: z
       .array(supportedStatesItemSchema)
       .nullable()

--- a/src/shared/database/migrations/0070_drop_service_states.sql
+++ b/src/shared/database/migrations/0070_drop_service_states.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "practice_details" DROP COLUMN "service_states";


### PR DESCRIPTION
## Summary

- `service_states` (migration 0046) was a US-only `string[]` that duplicated the more expressive `supported_states` structure (`[{ country, states? }]`)
- No data migration needed — greenfield, no existing users
- `supported_states` handles both country-level (`{ country: 'GB' }`) and state-level (`{ country: 'US', states: ['AL'] }`) licensing in one field

## Changes

- Migration 0070: `DROP COLUMN service_states`
- Removed from: Drizzle schema, Zod validation (input + response), types, serializer, management helpers
- Conflict-check simplified to a single `supported_states` read

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] PUT `/:id/details` with `supported_states: [{ country: "US", states: ["AL"] }]` saves correctly
- [ ] GET `/details/:slug` response no longer includes `service_states`
- [ ] Conflict-check warns when client state absent from `supported_states`
- [ ] Conflict-check silent when `supported_states` is null (practice hasn't configured jurisdictions yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced practice location state service availability tracking with improved data structure and validation for better accuracy in determining served states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->