### PR TITLE
perf(auth): cache session lookups in signed cookie

### DIFF
--- a/src/shared/auth/config/authConfig.ts
+++ b/src/shared/auth/config/authConfig.ts
@@ -7,6 +7,10 @@ export const AUTH_CONFIG = {
     expiresIn: 60 * 60 * 24, // 24 hours
     updateAge: 60 * 60, // 1 hour
     freshAge: 60 * 60 * 24, // 24 hours
+    cookieCache: {
+      enabled: true,
+      maxAge: 60, // 1 minute
+    },
   },
   emailAndPassword: {
     enabled: true,

--- a/test/shared/auth/auth-config.test.ts
+++ b/test/shared/auth/auth-config.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { AUTH_CONFIG } from '@/shared/auth/config/authConfig';
+
+describe('AUTH_CONFIG', () => {
+  it('caches session data in a short-lived signed cookie', () => {
+    expect(AUTH_CONFIG.session.cookieCache).toEqual({
+      enabled: true,
+      maxAge: 60,
+    });
+  });
+});


### PR DESCRIPTION
Caches successful session lookups for 60 seconds in Better Auth's signed cookie, allowing repeated `/get-session` requests to avoid querying PostgreSQL. This does not suppress client network requests; frontend request deduplication remains a separate concern.

Adds a focused regression test for the cache configuration.

Fixes #348

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session cookie caching is now enabled with automatic 60-second expiration. Configuration includes both enabled status and maximum age settings for session cookies.

* **Tests**
  * Added test coverage to validate that session cookie cache configuration is properly enabled with the correct 60-second maximum age setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->